### PR TITLE
bump tesseract version to sync with Ubuntu CI

### DIFF
--- a/dockerfiles/base-images:rocky8.7-1
+++ b/dockerfiles/base-images:rocky8.7-1
@@ -33,7 +33,7 @@ RUN set -ex && \
     ./configure && make && make install && \
     cp m4/* /usr/share/aclocal && \
     cd .. && \
-    git clone --depth 1  https://github.com/tesseract-ocr/tesseract.git tesseract-ocr && \
+    git clone --depth 1 --branch 5.3.1 https://github.com/tesseract-ocr/tesseract.git tesseract-ocr && \
     cd tesseract-ocr || exit && \
     export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig && \
     ./autogen.sh && ./configure --prefix=/usr/local --disable-shared --enable-static --with-extra-libraries=/usr/local/lib/ --with-extra-includes=/usr/local/lib/ && \


### PR DESCRIPTION
###  Summary

bump tesseract version to `5.3.1`. This version is the latest stable release of tesseract and also the version in Ubuntu CI.

### Test instructions
Built the docker image locally and checked version
```
# tesseract --version
tesseract 5.3.1
 leptonica-1.75.1
  libjpeg 6b (libjpeg-turbo 1.5.3) : libpng 1.6.34 : libtiff 4.0.9 : zlib 1.2.11 : libwebp 1.0.0

 Found NEON
 Found OpenMP 201511
```
