### PR TITLE
revert: undo the legacy provider openssl fix

### DIFF
--- a/dockerfiles/base-images:rocky9.2-9
+++ b/dockerfiles/base-images:rocky9.2-9
@@ -72,8 +72,3 @@ RUN dnf -y install bzip2-devel libffi-devel make git sqlite-devel openssl-devel 
     dnf -y groupremove "Development Tools" && \
     rm -rf /var/cache/yum/* && \
     dnf clean all
-
-# Enable legacy functions in openssl
-# This fixes crypto related errors on certain hosts
-# See also https://github.com/ethereum/execution-specs/issues/506
-RUN sed -i '/##legacy = legacy_sect/s/^##//; /##\[legacy_sect\]/s/^##//; /##activate = 1/s/^##//' /etc/ssl/openssl.cnf


### PR DESCRIPTION
Revert https://github.com/Unstructured-IO/base-images/pull/12 which is too broad in scope. We've identified a more suitable fix.