### PR TITLE
fix: add missing double quote for slim publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
   publish-images:
     strategy:
       matrix:
-        images: ["rocky9.2-9", rocky9.2-9-slim"]
+        images: ["rocky9.2-9", "rocky9.2-9-slim"]
     env:
       SHORT_SHA: ${{ needs.set-short-sha.outputs.short_sha }}
     runs-on: ubuntu-latest


### PR DESCRIPTION
Adds a missing double quote for the publish workflow matrix per the error [here](https://github.com/Unstructured-IO/base-images/actions/runs/7805198037/job/21294144570#step:5:2)