### PR TITLE
bug: pandoc not being installed, fixed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,14 +8,17 @@ CI:= $(shell echo $(CI))
 help: Makefile
 	@sed -n 's/^\(## \)\([a-zA-Z]\)/\2/p' $<
 
+## build-base-images:		build all the base images defined in this repo
 .PHONY: build-base-images
 build-base-images:
 	DOCKER_PLATFORM=$(DOCKER_PLATFORM) DOCKERFILE=$(DOCKERFILE) SHORT_SHA=$(SHORT_SHA) CI=$(CI) $(PROJECT_DIR)/scripts/build-base-images.sh
 
-.PHONY: tidy_shell
+## tidy-shell:			run the shell syntax linter to fix issues in-place
+.PHONY: tidy-shell
 tidy-shell:
 	shfmt -i 2 -l -w .
 
+## check-shell:			run the shell syntax linter, raising an error if any diff found
 .PHONY: check-shell
 check-shell:
 	shfmt -i 2 -d .

--- a/dockerfiles/deps/base.sh
+++ b/dockerfiles/deps/base.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -ex
+
 GPU_ENABLED=${GPU_ENABLED:-"true"}
 PANDOC_VERSION=${PANDOC_VERSION:-"3.1.9"}
 
@@ -32,9 +34,15 @@ cp /etc/yum.repos.d/rocky-devel.repo /etc/yum.repos.d/Rocky-Devel.repo
 dnf config-manager --enable crb
 
 # Needed for LibreOffice to install base components on aarch64
-pandoc_filename=pandoc-"$PANDOC_VERSION"-linux-"$ARCH".tar.gz
+if [ "$ARCH" == "aarch64" ]; then
+  PANDOC_ARCH="arm64"
+else
+  PANDOC_ARCH="amd64"
+fi
+pandoc_filename=pandoc-"$PANDOC_VERSION"-linux-"$PANDOC_ARCH".tar.gz
+pandoc_url=https://github.com/jgm/pandoc/releases/download/"$PANDOC_VERSION"/"$pandoc_filename"
 sed -i 's/enabled=0/enabled=1/g' /etc/yum.repos.d/Rocky-Devel.repo
-wget https://github.com/jgm/pandoc/releases/download/"$PANDOC_VERSION"/"$pandoc_filename"
+wget "$pandoc_url"
 tar xvzf "$pandoc_filename" --strip-components 1 -C '/usr/local'
 rm -rf "$pandoc_filename"
 dnf -y install libreoffice-writer libreoffice-base libreoffice-impress libreoffice-draw libreoffice-math libreoffice-core

--- a/dockerfiles/deps/python.sh
+++ b/dockerfiles/deps/python.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -ex
+
 dnf -y install bzip2-devel libffi-devel make git sqlite-devel openssl-devel
 dnf -y install python-pip
 pip3.9 install --upgrade setuptools pip

--- a/dockerfiles/deps/tesseract.sh
+++ b/dockerfiles/deps/tesseract.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+
 set -ex
 
 dnf install -y opencv opencv* zlib zlib-devel perl-core clang libpng libpng-devel libtiff libtiff-devel libwebp libwebp-devel libjpeg libjpeg-devel libjpeg-turbo-devel git-core libtool pkgconfig xz


### PR DESCRIPTION
### Description
There is no pandoc install file with the `aarch64` arch designation and the following portion was never copied over during the last refactor: 
```shell
if [ "$ARCH" == "aarch64" ]; then
  PANDOC_ARCH="arm64"
else
  PANDOC_ARCH="amd64"
fi
```
This will now set the arch appropriately when pulling down the pandoc file.

