### PR TITLE
fix: CI fails due to missing "Login to Quay.io" step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,12 @@ jobs:
       SHORT_SHA: ${{ needs.set-short-sha.outputs.short_sha }}
     steps:
       - uses: actions/checkout@v3
+      - name: Login to Quay.io
+        uses: docker/login-action@v2
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_IO_ROBOT_USERNAME }}
+          password: ${{ secrets.QUAY_IO_ROBOT_TOKEN }}
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
       - name: Download APKs for chainguard/wolfi-base

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Login to Quay.io
+        # build-base-images pushes images to quay.io when on the main branch
         uses: docker/login-action@v2
         with:
           registry: quay.io


### PR DESCRIPTION
###  Summary

CI on main fails, because of removed login action to quay.io: https://github.com/Unstructured-IO/base-images/pull/19/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL35-L40
![image](https://github.com/Unstructured-IO/base-images/assets/64484917/df29a4b5-feef-438c-9f95-77105d5fb1ef)
It turns out that the `build-base-images.sh` script tries to push images, but only when on the `main` branch, that's why I didn't see any error:




### Test instructions

