### PR TITLE
fix: disable publishing of ARM64 wolfi-based image in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,14 +88,21 @@ jobs:
         docker tag $DOCKER_BUILD_REPOSITORY:${{ matrix.image }}-amd64-$SHORT_SHA $DOCKER_BUILD_REPOSITORY:${{ matrix.image }}-amd64
         docker push $DOCKER_BUILD_REPOSITORY:${{ matrix.image }}-amd64
     - name: Pull ARM image
+      # wolfi-base is currently for AMD64 only
+      if: matrix.image != 'wolfi-base'
       run: |
         docker pull --platform linux/arm64 $DOCKER_BUILD_REPOSITORY:${{ matrix.image }}-arm64-$SHORT_SHA
         docker tag $DOCKER_BUILD_REPOSITORY:${{ matrix.image }}-arm64-$SHORT_SHA $DOCKER_BUILD_REPOSITORY:${{ matrix.image }}-arm64
         docker push $DOCKER_BUILD_REPOSITORY:${{ matrix.image }}-arm64
     - name: Push multiarch manifest
       run: |
-        docker manifest create $DOCKER_REPOSITORY/$DOCKER_IMAGE:${{ matrix.image }} $DOCKER_BUILD_REPOSITORY:${{ matrix.image }}-amd64 $DOCKER_BUILD_REPOSITORY:${{ matrix.image }}-arm64
-        docker manifest push $DOCKER_REPOSITORY/$DOCKER_IMAGE:${{ matrix.image }}
+        run: |
+          if [ "${{ matrix.image }}" = "wolfi-base" ]; then
+            docker manifest create $docker_repository/$docker_image:${{ matrix.image }} $docker_build_repository:${{ matrix.image }}-amd64
+          else
+            docker manifest create $DOCKER_REPOSITORY/$DOCKER_IMAGE:${{ matrix.image }} $DOCKER_BUILD_REPOSITORY:${{ matrix.image }}-amd64 $DOCKER_BUILD_REPOSITORY:${{ matrix.image }}-arm64
+          fi
+          docker manifest push $DOCKER_REPOSITORY/$DOCKER_IMAGE:${{ matrix.image }}
 
   shellcheck:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,10 +97,10 @@ jobs:
     - name: Push multiarch manifest
       run: |
         run: |
-          if [ "${{ matrix.image }}" = "wolfi-base" ]; then
-            docker manifest create $docker_repository/$docker_image:${{ matrix.image }} $docker_build_repository:${{ matrix.image }}-amd64
-          else
+          if [ "${{ matrix.image }}" != "wolfi-base" ]; then
             docker manifest create $DOCKER_REPOSITORY/$DOCKER_IMAGE:${{ matrix.image }} $DOCKER_BUILD_REPOSITORY:${{ matrix.image }}-amd64 $DOCKER_BUILD_REPOSITORY:${{ matrix.image }}-arm64
+          else
+            docker manifest create $docker_repository/$docker_image:${{ matrix.image }} $docker_build_repository:${{ matrix.image }}-amd64
           fi
           docker manifest push $DOCKER_REPOSITORY/$DOCKER_IMAGE:${{ matrix.image }}
 


### PR DESCRIPTION
###  Summary
Given that the ARM64 image isn't yet working, we're going to skip building it; therefore, skipping the attempt to publish a non-existent image makes sense too.

This PR attempt to fix such errors during the `publish-images` step on main
https://github.com/Unstructured-IO/base-images/actions/runs/9470215238/job/26097126232


