### PR TITLE
fix: syntax error in publish-images CI step and soffice initialization as non-root user

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,13 +96,12 @@ jobs:
         docker push $DOCKER_BUILD_REPOSITORY:${{ matrix.image }}-arm64
     - name: Push multiarch manifest
       run: |
-        run: |
-          if [ "${{ matrix.image }}" != "wolfi-base" ]; then
-            docker manifest create $DOCKER_REPOSITORY/$DOCKER_IMAGE:${{ matrix.image }} $DOCKER_BUILD_REPOSITORY:${{ matrix.image }}-amd64 $DOCKER_BUILD_REPOSITORY:${{ matrix.image }}-arm64
-          else
-            docker manifest create $docker_repository/$docker_image:${{ matrix.image }} $docker_build_repository:${{ matrix.image }}-amd64
-          fi
-          docker manifest push $DOCKER_REPOSITORY/$DOCKER_IMAGE:${{ matrix.image }}
+        if [ "${{ matrix.image }}" != "wolfi-base" ]; then
+          docker manifest create $DOCKER_REPOSITORY/$DOCKER_IMAGE:${{ matrix.image }} $DOCKER_BUILD_REPOSITORY:${{ matrix.image }}-amd64 $DOCKER_BUILD_REPOSITORY:${{ matrix.image }}-arm64
+        else
+          docker manifest create $DOCKER_REPOSITORY/$DOCKER_IMAGE:${{ matrix.image }} $DOCKER_BUILD_REPOSITORY:${{ matrix.image }}-amd64
+        fi
+        docker manifest push $DOCKER_REPOSITORY/$DOCKER_IMAGE:${{ matrix.image }}
 
   shellcheck:
     runs-on: ubuntu-latest

--- a/dockerfiles/wolfi-base/Dockerfile
+++ b/dockerfiles/wolfi-base/Dockerfile
@@ -20,5 +20,14 @@ RUN apk update && apk add py3.11-pip mesa-gl glib cmake libreoffice bash libmagi
     # soffice running twice explanation: https://github.com/jodconverter/jodconverter/issues/48#issuecomment-1863864333
     /usr/bin/soffice --headless || [ $? -eq 81 ] || exit 1
 
+ARG NB_UID=1000
+ARG NB_USER=notebook-user
+RUN addgroup --gid ${NB_UID} ${NB_USER} && \
+    adduser --disabled-password --gecos "" --uid ${NB_UID} -G ${NB_USER} ${NB_USER}
+
+ENV USER ${NB_USER}
+ENV HOME /home/${NB_USER}
 ENV TESSDATA_PREFIX=/usr/local/share/tessdata
+USER ${NB_USER}
+WORKDIR ${HOME}
 CMD ["/bin/bash"]

--- a/dockerfiles/wolfi-base/Dockerfile
+++ b/dockerfiles/wolfi-base/Dockerfile
@@ -14,11 +14,7 @@ RUN apk update && apk add py3.11-pip mesa-gl glib cmake libreoffice bash libmagi
     ln -s /usr/lib/libreoffice/program/soffice.bin /usr/bin/soffice && \
     chmod +x /usr/lib/libreoffice/program/soffice.bin && \
     chmod +x /usr/bin/libreoffice && \
-    chmod +x /usr/bin/soffice && \
-    # NOTE(mike): This dummy call is a workaround for libreoffice not executing commands properly at the start of the container.
-    # The issue is decribed here: https://github.com/Unstructured-IO/unstructured/issues/3105
-    # soffice running twice explanation: https://github.com/jodconverter/jodconverter/issues/48#issuecomment-1863864333
-    /usr/bin/soffice --headless || [ $? -eq 81 ] || exit 1
+    chmod +x /usr/bin/soffice
 
 ARG NB_UID=1000
 ARG NB_USER=notebook-user
@@ -28,6 +24,14 @@ RUN addgroup --gid ${NB_UID} ${NB_USER} && \
 ENV USER ${NB_USER}
 ENV HOME /home/${NB_USER}
 ENV TESSDATA_PREFIX=/usr/local/share/tessdata
+
+# NOTE(mike): This dummy call is a workaround for libreoffice not executing commands properly at the start of the container.
+# The issue is decribed here: https://github.com/Unstructured-IO/unstructured/issues/3105
+# soffice running twice explanation: https://github.com/jodconverter/jodconverter/issues/48#issuecomment-1863864333
+# It is crucial to run as a non-root user, otherwise the config file will be created in /root
+# Moreover, we expect the command to exit with code 81
 USER ${NB_USER}
+RUN /usr/bin/soffice --headless || [ $? -eq 81 ] || exit 1
+
 WORKDIR ${HOME}
 CMD ["/bin/bash"]


### PR DESCRIPTION
- [x] Fix a typo that prevented publishing to base-images in quay
- [x] Create non-root user in wolfi-base image
- [x] Initialize soffice as non-root user to generate configs in /home/$USER, instead of /root...
