### PR TITLE
fix: install libreoffice 7 apk from s3

### DIFF
--- a/dockerfiles/wolfi-base/Dockerfile
+++ b/dockerfiles/wolfi-base/Dockerfile
@@ -3,11 +3,12 @@ FROM cgr.dev/chainguard/wolfi-base:latest
 COPY ./docker-packages/*.apk packages/
 
 USER root
-RUN apk update && apk add py3.11-pip mesa-gl glib cmake libreoffice bash libmagic wget && \
+RUN apk update && apk add py3.11-pip mesa-gl glib cmake bash libmagic wget && \
     apk add --allow-untrusted packages/pandoc-3.1.8-r0.apk && \
     apk add --allow-untrusted packages/poppler-23.09.0-r0.apk && \
     apk add --allow-untrusted packages/leptonica-1.83.0-r0.apk && \
     apk add --allow-untrusted packages/tesseract-5.3.2-r0.apk && \
+    apk add --allow-untrusted packages/libreoffice-24-24.2.4.1-r0.67f8e014.apk && \
     mv /share/tessdata/configs /usr/local/share/tessdata/ && \
     mv /share/tessdata/tessconfigs /usr/local/share/tessdata/ && \
     ln -s /usr/lib/libreoffice/program/soffice.bin /usr/bin/libreoffice && \

--- a/dockerfiles/wolfi-base/Dockerfile
+++ b/dockerfiles/wolfi-base/Dockerfile
@@ -8,14 +8,14 @@ RUN apk update && apk add py3.11-pip mesa-gl glib cmake bash libmagic wget && \
     apk add --allow-untrusted packages/poppler-23.09.0-r0.apk && \
     apk add --allow-untrusted packages/leptonica-1.83.0-r0.apk && \
     apk add --allow-untrusted packages/tesseract-5.3.2-r0.apk && \
-    apk add --allow-untrusted packages/libreoffice-24-24.2.4.1-r0.67f8e014.apk && \
+    apk add --allow-untrusted packages/libreoffice-7.6.5-r0.apk && \
     apk cache clean && \
     rm -rf packages && \
     mv /share/tessdata/configs /usr/local/share/tessdata/ && \
     mv /share/tessdata/tessconfigs /usr/local/share/tessdata/ && \
-    ln -s /usr/lib/libreoffice/program/soffice.bin /usr/bin/libreoffice && \
-    ln -s /usr/lib/libreoffice/program/soffice.bin /usr/bin/soffice && \
-    chmod +x /usr/lib/libreoffice/program/soffice.bin && \
+    ln -s /usr/local/lib/libreoffice/program/soffice.bin /usr/bin/libreoffice && \
+    ln -s /usr/local/lib/libreoffice/program/soffice.bin /usr/bin/soffice && \
+    chmod +x /usr/local/lib/libreoffice/program/soffice.bin && \
     chmod +x /usr/bin/libreoffice && \
     chmod +x /usr/bin/soffice
 

--- a/dockerfiles/wolfi-base/Dockerfile
+++ b/dockerfiles/wolfi-base/Dockerfile
@@ -9,6 +9,8 @@ RUN apk update && apk add py3.11-pip mesa-gl glib cmake bash libmagic wget && \
     apk add --allow-untrusted packages/leptonica-1.83.0-r0.apk && \
     apk add --allow-untrusted packages/tesseract-5.3.2-r0.apk && \
     apk add --allow-untrusted packages/libreoffice-24-24.2.4.1-r0.67f8e014.apk && \
+    apk cache clean && \
+    rm -rf packages && \
     mv /share/tessdata/configs /usr/local/share/tessdata/ && \
     mv /share/tessdata/tessconfigs /usr/local/share/tessdata/ && \
     ln -s /usr/lib/libreoffice/program/soffice.bin /usr/bin/libreoffice && \

--- a/scripts/docker-dl-wolfi-packages.sh
+++ b/scripts/docker-dl-wolfi-packages.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 files=(
-  "libreoffice-24-24.2.4.1-r0.67f8e014.apk"
+  "libreoffice-7.6.5-r0.apk"
   "openjpeg-2.5.0-r0.apk"
   "poppler-23.09.0-r0.apk"
   "leptonica-1.83.0-r0.apk"

--- a/scripts/docker-dl-wolfi-packages.sh
+++ b/scripts/docker-dl-wolfi-packages.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 files=(
-  "libreoffice-7.6.5-r0.apk"
+  "libreoffice-24-24.2.4.1-r0.67f8e014.apk"
   "openjpeg-2.5.0-r0.apk"
   "poppler-23.09.0-r0.apk"
   "leptonica-1.83.0-r0.apk"


### PR DESCRIPTION
###  Summary

S3 location with APKs: https://utic-public-cf.s3.amazonaws.com

- [x] remove downloaded APKs after installation which were no longer needed, this alone reduced the image size by 1.2 GB ❗ 
- [x] replace official libreoffice package with our custom one (built using [melange](https://github.com/chainguard-dev/melange))
- [x] also test libreoffice 24 -> 🔴 does not work with .ppt files!

