### PR TITLE
fix: add tesseract into ubi9.4 build

### DIFF
--- a/dockerfiles/ubi9.4/Dockerfile
+++ b/dockerfiles/ubi9.4/Dockerfile
@@ -12,7 +12,7 @@ RUN --mount=type=secret,id=redhat_pw,uid=0 \
     --username $(cat /run/secrets/redhat_user) \
     --password $(cat /run/secrets/redhat_pw)  && \
   GPU_ENABLED=false /deps/base.sh  && \
-  # /deps/tesseract.sh && \
+  /deps/tesseract.sh && \
   /deps/python.sh && \
   rm -r /deps && \
   rm /etc/pki/entitlement/*.pem


### PR DESCRIPTION
###  Summary

Tesseract installation was commented out in the `ubi9.4` docker image.

### Test instructions

`unstructured-api` image works correctly with the `ubi9.4` base image using a model and file that requires tesseract.
