### PR TITLE
build: enable arm64 build for wolfi-os

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,12 +58,8 @@ jobs:
         uses: anchore/scan-action@v3
         with:
           image: "${{ env.DOCKER_BUILD_REPOSITORY }}:${{ matrix.image }}-${{ matrix.architecture }}-${{ env.SHORT_SHA }}"
-          severity-cutoff: high
+          severity-cutoff: critical
           fail-build: ${{ matrix.image == 'wolfi-base' }}
-          ignore:
-            # We have a follow on issue to fix this CVE. Details at link below.
-            # ref: https://nvd.nist.gov/vuln/detail/CVE-2018-20225
-            - vulnerability: CVE-2018-20225
           output-format: table
 
   publish-images:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
         uses: anchore/scan-action@v3
         with:
           image: "${{ env.DOCKER_BUILD_REPOSITORY }}:${{ matrix.image }}-${{ matrix.architecture }}-${{ env.SHORT_SHA }}"
-          severity-cutoff: critical
+          severity-cutoff: high
           fail-build: ${{ matrix.image == 'wolfi-base' }}
           ignore:
             # We have a follow on issue to fix this CVE. Details at link below.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,8 +58,8 @@ jobs:
         uses: anchore/scan-action@v3
         with:
           image: "${{ env.DOCKER_BUILD_REPOSITORY }}:${{ matrix.image }}-${{ matrix.architecture }}-${{ env.SHORT_SHA }}"
-          severity-cutoff: high
-          # fail-build: ${{ matrix.image == 'wolfi-base' }}
+          severity-cutoff: critical
+          fail-build: ${{ matrix.image == 'wolfi-base' }}
           output-format: table
 
   publish-images:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,10 @@ jobs:
           image: "${{ env.DOCKER_BUILD_REPOSITORY }}:${{ matrix.image }}-${{ matrix.architecture }}-${{ env.SHORT_SHA }}"
           severity-cutoff: critical
           fail-build: ${{ matrix.image == 'wolfi-base' }}
+          ignore:
+            # We have a follow on issue to fix this CVE. Details at link below.
+            # ref: https://nvd.nist.gov/vuln/detail/CVE-2018-20225
+            - vulnerability: CVE-2018-20225
           output-format: table
 
   publish-images:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,9 +26,6 @@ jobs:
       matrix:
         architecture: ["arm64", "amd64"]
         image: ["wolfi-base", "rocky9.2-10-gpu", "rocky9.2-10-slim", "rocky9.2-10-cpu"]
-        exclude:
-          - architecture: arm64
-            image: wolfi-base
     runs-on: ubuntu-latest-m
     needs: [set-short-sha]
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
         with:
           image: "${{ env.DOCKER_BUILD_REPOSITORY }}:${{ matrix.image }}-${{ matrix.architecture }}-${{ env.SHORT_SHA }}"
           severity-cutoff: high
-          fail-build: ${{ matrix.image == 'wolfi-base' }}
+          # fail-build: ${{ matrix.image == 'wolfi-base' }}
           output-format: table
 
   publish-images:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,9 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
       - name: Download APKs for chainguard/wolfi-base
-        if: matrix.architecture == 'amd64' && matrix.image == 'wolfi-base'
+        env:
+          ARCH: ${{ matrix.architecture }}
+        if: matrix.image == 'wolfi-base'
         run: make docker-dl-wolfi-packages
       - name: Build base images
         run: make build-base-images
@@ -88,19 +90,13 @@ jobs:
         docker tag $DOCKER_BUILD_REPOSITORY:${{ matrix.image }}-amd64-$SHORT_SHA $DOCKER_BUILD_REPOSITORY:${{ matrix.image }}-amd64
         docker push $DOCKER_BUILD_REPOSITORY:${{ matrix.image }}-amd64
     - name: Pull ARM image
-      # wolfi-base is currently for AMD64 only
-      if: matrix.image != 'wolfi-base'
       run: |
         docker pull --platform linux/arm64 $DOCKER_BUILD_REPOSITORY:${{ matrix.image }}-arm64-$SHORT_SHA
         docker tag $DOCKER_BUILD_REPOSITORY:${{ matrix.image }}-arm64-$SHORT_SHA $DOCKER_BUILD_REPOSITORY:${{ matrix.image }}-arm64
         docker push $DOCKER_BUILD_REPOSITORY:${{ matrix.image }}-arm64
     - name: Push multiarch manifest
       run: |
-        if [ "${{ matrix.image }}" != "wolfi-base" ]; then
-          docker manifest create $DOCKER_REPOSITORY/$DOCKER_IMAGE:${{ matrix.image }} $DOCKER_BUILD_REPOSITORY:${{ matrix.image }}-amd64 $DOCKER_BUILD_REPOSITORY:${{ matrix.image }}-arm64
-        else
-          docker manifest create $DOCKER_REPOSITORY/$DOCKER_IMAGE:${{ matrix.image }} $DOCKER_BUILD_REPOSITORY:${{ matrix.image }}-amd64
-        fi
+        docker manifest create $DOCKER_REPOSITORY/$DOCKER_IMAGE:${{ matrix.image }} $DOCKER_BUILD_REPOSITORY:${{ matrix.image }}-amd64 $DOCKER_BUILD_REPOSITORY:${{ matrix.image }}-arm64
         docker manifest push $DOCKER_REPOSITORY/$DOCKER_IMAGE:${{ matrix.image }}
 
   shellcheck:

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 
 # APK packages for the docker build
 docker-packages/*
+melange/packages/**

--- a/dockerfiles/ubi9.4/Dockerfile
+++ b/dockerfiles/ubi9.4/Dockerfile
@@ -12,7 +12,7 @@ RUN --mount=type=secret,id=redhat_pw,uid=0 \
     --username $(cat /run/secrets/redhat_user) \
     --password $(cat /run/secrets/redhat_pw)  && \
   GPU_ENABLED=false /deps/base.sh  && \
-  # /deps/tesseract.sh && \
+  /deps/tesseract.sh && \
   /deps/python.sh && \
   rm -r /deps && \
   rm /etc/pki/entitlement/*.pem

--- a/dockerfiles/wolfi-base/Dockerfile
+++ b/dockerfiles/wolfi-base/Dockerfile
@@ -34,7 +34,7 @@ ENV TESSDATA_PREFIX=/usr/local/share/tessdata
 # It is crucial to run as a non-root user, otherwise the config file will be created in /root
 # Moreover, we expect the command to exit with code 81
 USER ${NB_USER}
-RUN /usr/bin/soffice --headless || [ $? -eq 81 ] || exit 1
+# RUN /usr/bin/soffice --headless || [ $? -eq 81 ] || exit 1
 
 WORKDIR ${HOME}
 CMD ["/bin/bash"]

--- a/dockerfiles/wolfi-base/Dockerfile
+++ b/dockerfiles/wolfi-base/Dockerfile
@@ -8,16 +8,16 @@ RUN apk update && apk add py3.11-pip mesa-gl glib cmake bash libmagic wget && \
     apk add --allow-untrusted packages/poppler-23.09.0-r0.apk && \
     apk add --allow-untrusted packages/leptonica-1.83.0-r0.apk && \
     apk add --allow-untrusted packages/tesseract-5.3.2-r0.apk && \
-    apk add --allow-untrusted packages/libreoffice-7.6.5-r0.apk && \
+    # apk add --allow-untrusted packages/libreoffice-7.6.5-r0.apk && \
     apk cache clean && \
     rm -rf packages && \
     mv /share/tessdata/configs /usr/local/share/tessdata/ && \
     mv /share/tessdata/tessconfigs /usr/local/share/tessdata/ && \
-    ln -s /usr/local/lib/libreoffice/program/soffice.bin /usr/bin/libreoffice && \
-    ln -s /usr/local/lib/libreoffice/program/soffice.bin /usr/bin/soffice && \
-    chmod +x /usr/local/lib/libreoffice/program/soffice.bin && \
-    chmod +x /usr/bin/libreoffice && \
-    chmod +x /usr/bin/soffice
+    # ln -s /usr/local/lib/libreoffice/program/soffice.bin /usr/bin/libreoffice && \
+    # ln -s /usr/local/lib/libreoffice/program/soffice.bin /usr/bin/soffice && \
+    # chmod +x /usr/local/lib/libreoffice/program/soffice.bin && \
+    # chmod +x /usr/bin/libreoffice && \
+    # chmod +x /usr/bin/soffice
 
 ARG NB_UID=1000
 ARG NB_USER=notebook-user

--- a/dockerfiles/wolfi-base/Dockerfile
+++ b/dockerfiles/wolfi-base/Dockerfile
@@ -26,7 +26,7 @@ RUN addgroup --gid ${NB_UID} ${NB_USER} && \
 
 ENV USER ${NB_USER}
 ENV HOME /home/${NB_USER}
-ENV TESSDATA_PREFIX=/usr/local/share/tessdata
+# ENV TESSDATA_PREFIX=/usr/local/share/tessdata
 
 # NOTE(mike): This dummy call is a workaround for libreoffice not executing commands properly at the start of the container.
 # The issue is decribed here: https://github.com/Unstructured-IO/unstructured/issues/3105

--- a/dockerfiles/wolfi-base/Dockerfile
+++ b/dockerfiles/wolfi-base/Dockerfile
@@ -1,6 +1,7 @@
 # syntax=docker/dockerfile:experimental
 FROM cgr.dev/chainguard/wolfi-base:latest
 COPY ./docker-packages/*.apk packages/
+COPY ./scripts/install-wolfi-amd64-packages.sh install-wolfi-amd64-packages.sh
 
 USER root
 RUN apk update && apk add py3.11-pip mesa-gl glib cmake bash libmagic wget && \
@@ -8,16 +9,10 @@ RUN apk update && apk add py3.11-pip mesa-gl glib cmake bash libmagic wget && \
     apk add --allow-untrusted packages/poppler-23.09.0-r0.apk && \
     apk add --allow-untrusted packages/leptonica-1.83.0-r0.apk && \
     apk add --allow-untrusted packages/tesseract-5.3.2-r0.apk && \
-    # apk add --allow-untrusted packages/libreoffice-7.6.5-r0.apk && \
+    ./install-wolfi-amd64-packages.sh && \
+    rm install-wolfi-amd64-packages.sh && \
     apk cache clean && \
     rm -rf packages
-    # mv /share/tessdata/configs /usr/local/share/tessdata/ && \
-    # mv /share/tessdata/tessconfigs /usr/local/share/tessdata/
-    # ln -s /usr/local/lib/libreoffice/program/soffice.bin /usr/bin/libreoffice && \
-    # ln -s /usr/local/lib/libreoffice/program/soffice.bin /usr/bin/soffice && \
-    # chmod +x /usr/local/lib/libreoffice/program/soffice.bin && \
-    # chmod +x /usr/bin/libreoffice && \
-    # chmod +x /usr/bin/soffice
 
 ARG NB_UID=1000
 ARG NB_USER=notebook-user
@@ -26,15 +21,16 @@ RUN addgroup --gid ${NB_UID} ${NB_USER} && \
 
 ENV USER ${NB_USER}
 ENV HOME /home/${NB_USER}
-# ENV TESSDATA_PREFIX=/usr/local/share/tessdata
+COPY --chown=${NB_USER} scripts/initialize-libreoffice.sh ${HOME}/initialize-libreoffice.sh
+ENV TESSDATA_PREFIX=/usr/local/share/tessdata
+USER ${NB_USER}
+WORKDIR ${HOME}
 
 # NOTE(mike): This dummy call is a workaround for libreoffice not executing commands properly at the start of the container.
 # The issue is decribed here: https://github.com/Unstructured-IO/unstructured/issues/3105
 # soffice running twice explanation: https://github.com/jodconverter/jodconverter/issues/48#issuecomment-1863864333
 # It is crucial to run as a non-root user, otherwise the config file will be created in /root
 # Moreover, we expect the command to exit with code 81
-USER ${NB_USER}
-# RUN /usr/bin/soffice --headless || [ $? -eq 81 ] || exit 1
+RUN ./initialize-libreoffice.sh && rm initialize-libreoffice.sh
 
-WORKDIR ${HOME}
 CMD ["/bin/bash"]

--- a/dockerfiles/wolfi-base/Dockerfile
+++ b/dockerfiles/wolfi-base/Dockerfile
@@ -10,7 +10,7 @@ RUN apk update && apk add py3.11-pip mesa-gl glib cmake bash libmagic wget && \
     apk add --allow-untrusted packages/tesseract-5.3.2-r0.apk && \
     # apk add --allow-untrusted packages/libreoffice-7.6.5-r0.apk && \
     apk cache clean && \
-    rm -rf packages && \
+    rm -rf packages
     # mv /share/tessdata/configs /usr/local/share/tessdata/ && \
     # mv /share/tessdata/tessconfigs /usr/local/share/tessdata/
     # ln -s /usr/local/lib/libreoffice/program/soffice.bin /usr/bin/libreoffice && \

--- a/dockerfiles/wolfi-base/Dockerfile
+++ b/dockerfiles/wolfi-base/Dockerfile
@@ -7,12 +7,12 @@ RUN apk update && apk add py3.11-pip mesa-gl glib cmake bash libmagic wget && \
     apk add --allow-untrusted packages/pandoc-3.1.8-r0.apk && \
     apk add --allow-untrusted packages/poppler-23.09.0-r0.apk && \
     apk add --allow-untrusted packages/leptonica-1.83.0-r0.apk && \
-    apk add --allow-untrusted packages/tesseract-5.3.2-r0.apk && \
+    # apk add --allow-untrusted packages/tesseract-5.3.2-r0.apk && \
     # apk add --allow-untrusted packages/libreoffice-7.6.5-r0.apk && \
     apk cache clean && \
     rm -rf packages && \
-    mv /share/tessdata/configs /usr/local/share/tessdata/ && \
-    mv /share/tessdata/tessconfigs /usr/local/share/tessdata/ && \
+    # mv /share/tessdata/configs /usr/local/share/tessdata/ && \
+    # mv /share/tessdata/tessconfigs /usr/local/share/tessdata/ && \
     # ln -s /usr/local/lib/libreoffice/program/soffice.bin /usr/bin/libreoffice && \
     # ln -s /usr/local/lib/libreoffice/program/soffice.bin /usr/bin/soffice && \
     # chmod +x /usr/local/lib/libreoffice/program/soffice.bin && \

--- a/dockerfiles/wolfi-base/Dockerfile
+++ b/dockerfiles/wolfi-base/Dockerfile
@@ -7,12 +7,12 @@ RUN apk update && apk add py3.11-pip mesa-gl glib cmake bash libmagic wget && \
     apk add --allow-untrusted packages/pandoc-3.1.8-r0.apk && \
     apk add --allow-untrusted packages/poppler-23.09.0-r0.apk && \
     apk add --allow-untrusted packages/leptonica-1.83.0-r0.apk && \
-    # apk add --allow-untrusted packages/tesseract-5.3.2-r0.apk && \
+    apk add --allow-untrusted packages/tesseract-5.3.2-r0.apk && \
     # apk add --allow-untrusted packages/libreoffice-7.6.5-r0.apk && \
     apk cache clean && \
-    rm -rf packages
-    # mv /share/tessdata/configs /usr/local/share/tessdata/ && \
-    # mv /share/tessdata/tessconfigs /usr/local/share/tessdata/ && \
+    rm -rf packages && \
+    mv /share/tessdata/configs /usr/local/share/tessdata/ && \
+    mv /share/tessdata/tessconfigs /usr/local/share/tessdata/
     # ln -s /usr/local/lib/libreoffice/program/soffice.bin /usr/bin/libreoffice && \
     # ln -s /usr/local/lib/libreoffice/program/soffice.bin /usr/bin/soffice && \
     # chmod +x /usr/local/lib/libreoffice/program/soffice.bin && \

--- a/dockerfiles/wolfi-base/Dockerfile
+++ b/dockerfiles/wolfi-base/Dockerfile
@@ -11,8 +11,8 @@ RUN apk update && apk add py3.11-pip mesa-gl glib cmake bash libmagic wget && \
     # apk add --allow-untrusted packages/libreoffice-7.6.5-r0.apk && \
     apk cache clean && \
     rm -rf packages && \
-    mv /share/tessdata/configs /usr/local/share/tessdata/ && \
-    mv /share/tessdata/tessconfigs /usr/local/share/tessdata/
+    # mv /share/tessdata/configs /usr/local/share/tessdata/ && \
+    # mv /share/tessdata/tessconfigs /usr/local/share/tessdata/
     # ln -s /usr/local/lib/libreoffice/program/soffice.bin /usr/bin/libreoffice && \
     # ln -s /usr/local/lib/libreoffice/program/soffice.bin /usr/bin/soffice && \
     # chmod +x /usr/local/lib/libreoffice/program/soffice.bin && \

--- a/dockerfiles/wolfi-base/Dockerfile
+++ b/dockerfiles/wolfi-base/Dockerfile
@@ -10,7 +10,7 @@ RUN apk update && apk add py3.11-pip mesa-gl glib cmake bash libmagic wget && \
     # apk add --allow-untrusted packages/tesseract-5.3.2-r0.apk && \
     # apk add --allow-untrusted packages/libreoffice-7.6.5-r0.apk && \
     apk cache clean && \
-    rm -rf packages && \
+    rm -rf packages
     # mv /share/tessdata/configs /usr/local/share/tessdata/ && \
     # mv /share/tessdata/tessconfigs /usr/local/share/tessdata/ && \
     # ln -s /usr/local/lib/libreoffice/program/soffice.bin /usr/bin/libreoffice && \

--- a/melange/leptonica.yaml
+++ b/melange/leptonica.yaml
@@ -1,0 +1,53 @@
+package:
+  name: leptonica
+  version: 1.83.0
+  description: leptonica compiled package for Wolfi based distros
+  target-architecture:
+    - x86_64
+    - aarch64
+  copyright:
+    - license: Apache-2.0
+      paths:
+        - "*"
+
+environment:
+  contents:
+    repositories:
+      - https://packages.wolfi.dev/os
+    keyring:
+      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    packages:
+      - wolfi-base
+      - ca-certificates
+      - gcc
+      - bash
+      - gcc-6
+      - linux-headers
+      - git
+      - autoconf
+      - coreutils
+      - build-base
+      - libtool
+      - automake
+      - make
+      - file
+      - tiff-dev
+      - libpng-dev
+      - libjpeg-dev
+      - zlib-dev
+      - autoconf
+      - pkgconf-dev
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://github.com/DanBloomberg/leptonica/releases/download/1.83.1/leptonica-1.83.1.tar.gz
+      expected-sha256: 8f18615e0743af7df7f50985c730dfcf0c93548073d1f56621e4156a8b54d3dd
+  - runs: |
+      mkdir -p ${{targets.destdir}}/leptonica ${{targets.destdir}}/usr/local/lib ${{targets.destdir}}/usr/local/include ${{targets.destdir}}/usr/local/bin
+      ./configure --prefix=$HOME/local
+      make -j$(nproc)
+      make install
+      cp -R $HOME/local/lib/* ${{targets.destdir}}/usr/local/lib/
+      cp -R $HOME/local/include/* ${{targets.destdir}}/usr/local/include/
+      cp -R $HOME/local/bin/* ${{targets.destdir}}/usr/local/bin/

--- a/melange/libreoffice.yaml
+++ b/melange/libreoffice.yaml
@@ -1,0 +1,125 @@
+package:
+  name: libreoffice
+  version: 7.5.4
+  description: Libreoffice compiled package for Wolfi based distros
+  target-architecture:
+    - x86_64
+    - aarch64
+  copyright:
+    - license: Mozilla Public License v2.0
+      paths:
+        - "*"
+
+environment:
+  contents:
+    repositories:
+      - https://packages.wolfi.dev/os
+      - '@local ./packages'
+    keyring:
+      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    packages:
+      - wolfi-base
+      - ca-certificates
+      - gcc
+      - pandoc
+      - openjpeg
+      - gcc-6
+      - bash
+      - linux-headers
+      - git
+      - autoconf
+      - coreutils
+      - build-base
+      - libtool
+      - automake
+      - make
+      - autoconf
+      - pkgconf-dev
+      - zip
+      - libxext-dev
+      - libxext
+      - ncurses-dev
+      - busybox
+      - libeconf-dev
+      - linux-pam-dev
+      - libcap-ng-dev
+      - gnutls
+      - libtool
+      - bison
+      - cups-dev
+      - fontconfig-dev
+      - libxslt-dev
+      - libxslt
+      - krb5-dev
+      - gnutar
+      - freetype-dev
+      - freetype
+      - icu
+      - gperf
+      - expat
+      - expat-dev
+      - libxml2-dev
+      - libxml2
+      - zlib-dev
+      - mercurial
+      - ninja
+      - python3
+      - python3-dev
+      - py3-pip
+      - libcurl4
+      - curl-dev
+      - libassuan-dev
+      - libjpeg-dev
+      - libassuan
+      - libice-dev
+      - libice
+      - libsm-dev
+      - libsm
+      - libxrender-dev
+      - libxrender
+      - libxt-dev
+      - libxt
+      - libx11-dev
+      - libx11-static
+      - libx11
+      - flex-dev
+      - curl
+      - patch
+      - diffutils
+      - openjdk-20
+      - openjdk-20-default-jvm
+      - openjdk-20-jre
+      - openjdk-20-jre-base
+      - libxml2-py3
+      - libxml2-utils
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://download.documentfoundation.org/libreoffice/src/7.5.4/libreoffice-7.5.4.2.tar.xz
+      expected-sha256: 68bbd1b79ffa4c33ed80f25520b9e6d69e3be23c9b4a0f0c9d859cc9a24865e8
+  - runs: |
+      mkdir $HOME/local
+      mkdir -p ${{targets.destdir}}/usr/local/lib/
+      ./autogen.sh \
+      --prefix=$HOME/local \
+      --enable-release-build=yes \
+      --enable-python=system \
+      --with-system-curl \
+      --with-system-expat \
+      --without-lxml \
+      --without-system-libxml \
+      --with-system-jpeg \
+      --with-system-zlib \
+      --disable-gui \
+      --disable-cups \
+      --disable-lotuswordpro \
+      --without-java \
+      --without-krb5 \
+      --without-system-dicts \
+      --without-system-nss && \
+      make -j$(nproc) && \
+      make install
+  - runs: |
+      mkdir -p ${{targets.destdir}}/usr/local/lib/
+      cp -R $HOME/local/ ${{targets.destdir}}

--- a/melange/openjpeg.yaml
+++ b/melange/openjpeg.yaml
@@ -1,0 +1,59 @@
+package:
+  name: openjpeg
+  version: 2.5.0
+  description: OpenJPEG library compiled package for Wolfi based distros
+  target-architecture:
+    - x86_64
+    - aarch64
+  copyright:
+    - license: 2-clauses * BSD License
+      paths:
+        - "*"
+
+environment:
+  contents:
+    repositories:
+      - https://packages.wolfi.dev/os
+    keyring:
+      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    packages:
+      - boost-dev
+      - wolfi-base
+      - ca-certificates
+      - gcc
+      - gzip
+      - gnutar
+      - bash
+      - gcc-6
+      - linux-headers
+      - git
+      - autoconf
+      - coreutils
+      - build-base
+      - libtool
+      - automake
+      - make
+      - autoconf
+      - pkgconf-dev
+      - libjpeg-dev
+      - cmake
+      - freetype-dev
+      - fontconfig-dev
+      - libjpeg-turbo
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://github.com/uclouvain/openjpeg/archive/refs/tags/v2.5.0.tar.gz
+      expected-sha256: 0333806d6adecc6f7a91243b2b839ff4d2053823634d4f6ed7a59bc87409122a
+  - runs: |
+      mkdir source
+      mv * source || true
+      mkdir -p "${{targets.destdir}}"/usr/local/lib \
+        "${{targets.destdir}}"/usr/local/lib64 \
+        "${{targets.destdir}}"/usr/local/bin/ \
+        "${{targets.destdir}}"/usr/local/lib64  \
+        "${{targets.destdir}}"/usr/local/lib/openjpeg-2.5
+      cmake ./source -DCMAKE_BUILD_TYPE=Release
+      make -j$(nproc)
+      make install DESTDIR="${{targets.destdir}}"

--- a/melange/pandoc.yaml
+++ b/melange/pandoc.yaml
@@ -1,0 +1,35 @@
+package:
+  name: pandoc
+  version: 3.1.8
+  description: pandoc compiled package for Wolfi based distros
+  target-architecture:
+    - x86_64
+    - aarch64
+  copyright:
+    - license: Apache-2.0
+      paths:
+        - "*"
+
+environment:
+  contents:
+    repositories:
+      - https://packages.wolfi.dev/os
+    keyring:
+      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    packages:
+      - wolfi-base
+      - wget
+      - gnutar
+      - gzip
+
+pipeline:
+  - runs: |
+      ARCH=$(uname -m)
+      if [ "$ARCH" = "x86_64" ]; then
+        ARCH="amd64"
+      elif [ "$ARCH" = "aarch64" ]; then
+        ARCH="arm64"
+      fi
+      wget "https://github.com/jgm/pandoc/releases/download/3.1.8/pandoc-3.1.8-linux-$ARCH.tar.gz"
+      mkdir -p ${{targets.destdir}}/usr/local
+      tar -xvf pandoc-3.1.8-linux-$ARCH.tar.gz --strip-components 1 -C "${{targets.destdir}}/usr/local"

--- a/melange/poppler.yaml
+++ b/melange/poppler.yaml
@@ -1,0 +1,71 @@
+package:
+  name: poppler
+  version: 23.09.0
+  description: poppler compiled package for Wolfi based distros
+  target-architecture:
+    - x86_64
+    - aarch64
+  copyright:
+    - license: GNU General Public License v3.0
+      paths:
+        - "*"
+
+environment:
+  contents:
+    repositories:
+      - https://packages.wolfi.dev/os
+      - '@local ./packages'
+    keyring:
+      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    packages:
+      - boost-dev
+      - boost-static
+      - wolfi-base
+      - ca-certificates
+      - gcc
+      - openjpeg@local
+      - expat-dev
+      - bash
+      - tiff-dev
+      - libpng-dev
+      - curl-dev
+      - zlib-dev
+      - cairo-dev
+      - gcc-6
+      - linux-headers
+      - git
+      - ninja
+      - glib
+      - glib-dev
+      - glibc-dev
+      - autoconf
+      - coreutils
+      - build-base
+      - libtool
+      - automake
+      - make
+      - autoconf
+      - pkgconf-dev
+      - libjpeg-dev
+      - cmake
+      - freetype-dev
+      - fontconfig-dev
+      - libjpeg-turbo
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://poppler.freedesktop.org/poppler-23.09.0.tar.xz
+      expected-sha256: 80d1d44dd8bdf4ac1a47d56c5065075eb9991790974b1ed7d14b972acde88e55
+  - runs: |
+      tar -xf poppler-23.09.0.tar.xz
+      cd poppler-23.09.0/
+      mkdir source
+      mv * source || true
+      mkdir -p "${{targets.destdir}}"/usr/local/lib \
+        "${{targets.destdir}}"/usr/local/lib64 \
+        "${{targets.destdir}}"/usr/local/bin/
+      cmake ./source -DCMAKE_BUILD_TYPE=Release
+      make -j$(nproc)
+      make install DESTDIR="${{targets.destdir}}"
+

--- a/melange/tesseract.yaml
+++ b/melange/tesseract.yaml
@@ -63,12 +63,15 @@ pipeline:
       cd tesseract
       cp /usr/local/include/leptonica/* ./include
       ./autogen.sh
-      ./configure --prefix="${{targets.destdir}}" --with-extra-libraries=/usr/local/lib --with-extra-includes=/usr/local/include
+      ./configure --prefix=/usr/local --with-extra-libraries=/usr/local/lib --with-extra-includes=/usr/local/include
       make -j$(nproc)
       make install
   - runs: |
       mkdir -p "${{targets.destdir}}"/usr/local/share/tessdata
       git clone https://github.com/tesseract-ocr/tessdata.git
       cp tessdata/*.traineddata "${{targets.destdir}}"/usr/local/share/tessdata
+      git clone https://github.com/tesseract-ocr/tessconfigs.git
+      cp -r tessconfigs/configs "${{targets.destdir}}"/usr/local/share/tessdata
+      cp -r tessconfigs/tessconfigs "${{targets.destdir}}"/usr/local/share/tessdata
 
 

--- a/melange/tesseract.yaml
+++ b/melange/tesseract.yaml
@@ -1,0 +1,74 @@
+package:
+  name: tesseract
+  version: 5.3.2
+  description: Tesseract compiled package for Wolfi based distros
+  target-architecture:
+    - x86_64
+    - aarch64
+  copyright:
+    - license: Apache-2.0
+      paths:
+        - "*"
+
+environment:
+  contents:
+    repositories:
+      - https://packages.wolfi.dev/os
+      - '@local ./packages'
+    keyring:
+      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    packages:
+      - wolfi-base
+      - ca-certificates
+      - gcc
+      - bash
+      - leptonica@local
+      - gcc-6
+      - linux-headers
+      - git
+      - glibc-dev
+      - autoconf
+      - coreutils
+      - build-base
+      - libtool
+      - automake
+      - make
+      - autoconf
+      - pkgconf-dev
+      - libffi-dev
+      - libjpeg-dev
+      - zlib-dev
+      - libjpeg-turbo
+      - lz4-dev
+      - tiff-dev
+      - libwebp-dev
+      - libpng-dev
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://mirror.team-cymru.com/gnu/autoconf-archive/autoconf-archive-2017.09.28.tar.xz
+      expected-sha256: 5c9fb5845b38b28982a3ef12836f76b35f46799ef4a2e46b48e2bd3c6182fa01
+  - runs: |
+      tar -xvf autoconf-archive-2017.09.28.tar.xz
+      cd autoconf-archive-2017.09.28
+      ./configure --prefix="${{targets.destdir}}"
+      make -j$(nproc)
+      make install
+      mkdir -p "${{targets.destdir}}"/usr/share/aclocal
+      cp m4/* "${{targets.destdir}}"/usr/share/aclocal
+      git clone --depth 1 --branch 5.3.2 https://github.com/tesseract-ocr/tesseract.git
+      export PATH=$PATH:/usr/local/lib/
+      export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig
+      cd tesseract
+      cp /usr/local/include/leptonica/* ./include
+      ./autogen.sh
+      ./configure --prefix="${{targets.destdir}}" --with-extra-libraries=/usr/local/lib --with-extra-includes=/usr/local/include
+      make -j$(nproc)
+      make install
+  - runs: |
+      mkdir -p "${{targets.destdir}}"/usr/local/share/tessdata
+      git clone https://github.com/tesseract-ocr/tessdata.git
+      cp tessdata/*.traineddata "${{targets.destdir}}"/usr/local/share/tessdata
+
+

--- a/scripts/build-base-images.sh
+++ b/scripts/build-base-images.sh
@@ -45,7 +45,6 @@ else
   DOCKER_BUILD_CMD=("${BUILDX_COMMAND[@]}"
     --build-arg PIP_VERSION="$PIP_VERSION"
     --build-arg BUILDKIT_INLINE_CACHE=1
-    --build-arg ARCH="$ARCH"
     --progress plain
     -t "$DOCKER_IMAGE-$SHORT_SHA" -f "./dockerfiles/$DOCKERFILE/Dockerfile" .)
 fi

--- a/scripts/build-base-images.sh
+++ b/scripts/build-base-images.sh
@@ -45,6 +45,7 @@ else
   DOCKER_BUILD_CMD=("${BUILDX_COMMAND[@]}"
     --build-arg PIP_VERSION="$PIP_VERSION"
     --build-arg BUILDKIT_INLINE_CACHE=1
+    --build-arg ARCH="$ARCH"
     --progress plain
     -t "$DOCKER_IMAGE-$SHORT_SHA" -f "./dockerfiles/$DOCKERFILE/Dockerfile" .)
 fi

--- a/scripts/docker-dl-wolfi-packages.sh
+++ b/scripts/docker-dl-wolfi-packages.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [ "${ARCH}" = "arm64" ] || [ "${ARCH}" = "aarch64" ]; then
+if [ "$ARCH" = "arm64" ] || [ "$ARCH" = "aarch64" ]; then
   files=(
     "openjpeg-2.5.0-r0-aarch64.apk"
     "poppler-23.09.0-r0-aarch64.apk"
@@ -29,7 +29,7 @@ for file in "${files[@]}"; do
   wget "https://utic-public-cf.s3.amazonaws.com/$file" -P "$directory"
 done
 
-if [ "${ARCH}" = "arm64" ] || [ "${ARCH}" = "aarch64" ]; then
+if [ "$ARCH" = "arm64" ] || [ "$ARCH" = "aarch64" ]; then
   OLD_EXT="-aarch64.apk"
   NEW_EXT=".apk"
   for FILE in "$directory"/*"$OLD_EXT"; do

--- a/scripts/docker-dl-wolfi-packages.sh
+++ b/scripts/docker-dl-wolfi-packages.sh
@@ -1,14 +1,25 @@
 #!/bin/bash
 
-files=(
-  "libreoffice-7.6.5-r0.apk"
-  "openjpeg-2.5.0-r0.apk"
-  "poppler-23.09.0-r0.apk"
-  "leptonica-1.83.0-r0.apk"
-  "pandoc-3.1.8-r0.apk"
-  "tesseract-5.3.2-r0.apk"
-  "nltk_data.tgz"
-)
+if [ "${ARCH}" = "arm64" ] || [ "${ARCH}" = "aarch64" ]; then
+  files=(
+    "openjpeg-2.5.0-r0-aarch64.apk"
+    "poppler-23.09.0-r0-aarch64.apk"
+    "leptonica-1.83.0-r0-aarch64.apk"
+    "pandoc-3.1.8-r0-aarch64.apk"
+    "tesseract-5.3.2-r0-aarch64.apk"
+    "nltk_data.tgz"
+  )
+else
+  files=(
+    "libreoffice-7.6.5-r0.apk"
+    "openjpeg-2.5.0-r0.apk"
+    "poppler-23.09.0-r0.apk"
+    "leptonica-1.83.0-r0.apk"
+    "pandoc-3.1.8-r0.apk"
+    "tesseract-5.3.2-r0.apk"
+    "nltk_data.tgz"
+  )
+fi
 
 directory="docker-packages"
 mkdir -p "${directory}"

--- a/scripts/docker-dl-wolfi-packages.sh
+++ b/scripts/docker-dl-wolfi-packages.sh
@@ -29,6 +29,8 @@ for file in "${files[@]}"; do
   wget "https://utic-public-cf.s3.amazonaws.com/$file" -P "$directory"
 done
 
+# NOTE(robinson) - renames the aarch64 specific APKs to replace -aarch.apk with .apk
+# so the apk add steps in the Dockerfile are unchanged between arm64 and amd64
 if [ "$ARCH" = "arm64" ] || [ "$ARCH" = "aarch64" ]; then
   OLD_EXT="-aarch64.apk"
   NEW_EXT=".apk"

--- a/scripts/docker-dl-wolfi-packages.sh
+++ b/scripts/docker-dl-wolfi-packages.sh
@@ -33,6 +33,7 @@ if [ "$ARCH" = "arm64" ] || [ "$ARCH" = "aarch64" ]; then
   OLD_EXT="-aarch64.apk"
   NEW_EXT=".apk"
   for FILE in "$directory"/*"$OLD_EXT"; do
+    # shellcheck disable=SC2295
     BASE_NAME="${FILE%$OLD_EXT}"
     NEW_FILE="${BASE_NAME}${NEW_EXT}"
     mv "$FILE" "$NEW_FILE"

--- a/scripts/docker-dl-wolfi-packages.sh
+++ b/scripts/docker-dl-wolfi-packages.sh
@@ -29,4 +29,14 @@ for file in "${files[@]}"; do
   wget "https://utic-public-cf.s3.amazonaws.com/$file" -P "$directory"
 done
 
+if [ "${ARCH}" = "arm64" ] || [ "${ARCH}" = "aarch64" ]; then
+  OLD_EXT="-aarch64.apk"
+  NEW_EXT=".apk"
+  for FILE in "$directory"/*"$OLD_EXT"; do
+    BASE_NAME="${FILE%$OLD_EXT}"
+    NEW_FILE="${BASE_NAME}${NEW_EXT}"
+    mv "$FILE" "$NEW_FILE"
+  done
+fi
+
 echo "Downloads complete."

--- a/scripts/initialize-libreoffice.sh
+++ b/scripts/initialize-libreoffice.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 if [ "$ARCH" != "arm64" ] && [ "$ARCH" != "aarch64" ]; then
-    /usr/bin/soffice --headless || [ $? -eq 81 ] || exit 1
+  /usr/bin/soffice --headless || [ $? -eq 81 ] || exit 1
 fi

--- a/scripts/initialize-libreoffice.sh
+++ b/scripts/initialize-libreoffice.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
-if [ "$ARCH" != "arm64" ] && [ "$ARCH" != "aarch64" ]; then
+ARCH=$(uname -m)
+
+if [[ "$ARCH" == "x86_64" ]] || [[ "$ARCH" == "amd64" ]]; then
   /usr/bin/soffice --headless || [ $? -eq 81 ] || exit 1
 fi

--- a/scripts/initialize-libreoffice.sh
+++ b/scripts/initialize-libreoffice.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+if [ "$ARCH" != "arm64" ] && [ "$ARCH" != "aarch64" ]; then
+    /usr/bin/soffice --headless || [ $? -eq 81 ] || exit 1
+fi

--- a/scripts/install-wolfi-amd64-packages.sh
+++ b/scripts/install-wolfi-amd64-packages.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+if [ "$ARCH" != "arm64" ] && [ "$ARCH" != "aarch64" ]; then
+    apk add --allow-untrusted packages/libreoffice-7.6.5-r0.apk && \
+    mv /share/tessdata/configs /usr/local/share/tessdata/ && \
+    mv /share/tessdata/tessconfigs /usr/local/share/tessdata/ && \
+    ln -s /usr/local/lib/libreoffice/program/soffice.bin /usr/bin/libreoffice && \
+    ln -s /usr/local/lib/libreoffice/program/soffice.bin /usr/bin/soffice && \
+    chmod +x /usr/local/lib/libreoffice/program/soffice.bin && \
+    chmod +x /usr/bin/libreoffice && \
+    chmod +x /usr/bin/soffice
+fi

--- a/scripts/install-wolfi-amd64-packages.sh
+++ b/scripts/install-wolfi-amd64-packages.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-if [ "$ARCH" != "arm64" ] && [ "$ARCH" != "aarch64" ]; then
+ARCH=$(uname -m)
+
+if [[ "$ARCH" == "x86_64" ]] || [[ "$ARCH" == "amd64" ]]; then
   apk add --allow-untrusted packages/libreoffice-7.6.5-r0.apk &&
     mv /share/tessdata/configs /usr/local/share/tessdata/ &&
     mv /share/tessdata/tessconfigs /usr/local/share/tessdata/ &&

--- a/scripts/install-wolfi-amd64-packages.sh
+++ b/scripts/install-wolfi-amd64-packages.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 
 if [ "$ARCH" != "arm64" ] && [ "$ARCH" != "aarch64" ]; then
-    apk add --allow-untrusted packages/libreoffice-7.6.5-r0.apk && \
-    mv /share/tessdata/configs /usr/local/share/tessdata/ && \
-    mv /share/tessdata/tessconfigs /usr/local/share/tessdata/ && \
-    ln -s /usr/local/lib/libreoffice/program/soffice.bin /usr/bin/libreoffice && \
-    ln -s /usr/local/lib/libreoffice/program/soffice.bin /usr/bin/soffice && \
-    chmod +x /usr/local/lib/libreoffice/program/soffice.bin && \
-    chmod +x /usr/bin/libreoffice && \
+  apk add --allow-untrusted packages/libreoffice-7.6.5-r0.apk &&
+    mv /share/tessdata/configs /usr/local/share/tessdata/ &&
+    mv /share/tessdata/tessconfigs /usr/local/share/tessdata/ &&
+    ln -s /usr/local/lib/libreoffice/program/soffice.bin /usr/bin/libreoffice &&
+    ln -s /usr/local/lib/libreoffice/program/soffice.bin /usr/bin/soffice &&
+    chmod +x /usr/local/lib/libreoffice/program/soffice.bin &&
+    chmod +x /usr/bin/libreoffice &&
     chmod +x /usr/bin/soffice
 fi


### PR DESCRIPTION
### Summary

Updates the `wolfi-base` Dockerfile to support both `arm64` and `amd64` builds. Includes the following changes:
- Updates to the `melange` configs originally implemented by @tabossert on [this branch](https://github.com/Unstructured-IO/base-images/tree/trevor/melange) to build all of the packages except `libreoffice` for `arm64`.
- Scripts for different `arm64` and `amd64` install logic
- Enabling the `arm64` build in CI

Because we do not yet have an `arm64` build for `libreoffice`, the `arm64` version of the image does not currently support `.doc`, `.ppt`, or `.xls` documents, though it does support `.docx`, `.pptx`, and `.xlsx`.

There are following on issues to address the following items:
- Addresses a `pip` CVE that appeared on the scans in this PR, but is unrelated to the PR
- Follow on issue to add `tessconfig` into the `amd64` APK for `tesseract`, which will avoid one of the distinct code paths for `amd64`
- Follow on issue to investigate creating an `arm64` build for `libreoffice.