### PR TITLE
fix: correct short sha env var syntax in publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,17 +83,17 @@ jobs:
         password: ${{ secrets.QUAY_IO_ROBOT_TOKEN }}
     - name: Pull AMD image
       run: |
-        docker pull --platform linux/amd64 $DOCKER_BUILD_REPOSITORY:${{ matrix.image }}-amd64-$SHORT_SHA
-        docker tag $DOCKER_BUILD_REPOSITORY:${{ matrix.image }}-amd64-$SHORT_SHA $DOCKER_BUILD_REPOSITORY:${{ matrix.image }}-amd64
+        docker pull --platform linux/amd64 $DOCKER_BUILD_REPOSITORY:${{ matrix.image }}-amd64-${{ env.SHORT_SHA }}
+        docker tag $DOCKER_BUILD_REPOSITORY:${{ matrix.image }}-amd64-${{ env.SHORT_SHA }} $DOCKER_BUILD_REPOSITORY:${{ matrix.image }}-amd64
         docker push $DOCKER_BUILD_REPOSITORY:${{ matrix.image }}-amd64
     - name: Pull ARM image
       run: |
-        docker pull --platform linux/arm64 $DOCKER_BUILD_REPOSITORY:${{ matrix.image }}-arm64-$SHORT_SHA
-        docker tag $DOCKER_BUILD_REPOSITORY:${{ matrix.image }}-arm64-$SHORT_SHA $DOCKER_BUILD_REPOSITORY:${{ matrix.image }}-arm64
+        docker pull --platform linux/arm64 $DOCKER_BUILD_REPOSITORY:${{ matrix.image }}-arm64-${{ env.SHORT_SHA }}
+        docker tag $DOCKER_BUILD_REPOSITORY:${{ matrix.image }}-arm64-${{ env.SHORT_SHA }} $DOCKER_BUILD_REPOSITORY:${{ matrix.image }}-arm64
         docker push $DOCKER_BUILD_REPOSITORY:${{ matrix.image }}-arm64
     - name: Push multiarch manifest with short SHA
       env:
-        IMAGE_TAG: ${{ matrix.image }}-$SHORT_SHA
+        IMAGE_TAG: ${{ matrix.image }}-${{ env.SHORT_SHA }}
       run: |
         docker manifest create $DOCKER_REPOSITORY/$DOCKER_IMAGE:${IMAGE_TAG} $DOCKER_BUILD_REPOSITORY:${{ matrix.image }}-amd64 $DOCKER_BUILD_REPOSITORY:${{ matrix.image }}-arm64
         docker manifest push $DOCKER_REPOSITORY/$DOCKER_IMAGE:${IMAGE_TAG}


### PR DESCRIPTION
###  Summary

Fixes a syntax error referencing the `SHORT_SHA` environment variable that appeared to cause [this CI job failure](https://github.com/Unstructured-IO/base-images/actions/runs/9686380207/job/26761297781). 

