### PR TITLE
fix: revert back to `libreoffice7` in `amd64` build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
         uses: anchore/scan-action@v3
         with:
           image: "${{ env.DOCKER_BUILD_REPOSITORY }}:${{ matrix.image }}-${{ matrix.architecture }}-${{ env.SHORT_SHA }}"
-          severity-cutoff: medium
+          severity-cutoff: high
           fail-build: ${{ matrix.image == 'wolfi-base' }}
           output-format: table
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,17 +83,17 @@ jobs:
         password: ${{ secrets.QUAY_IO_ROBOT_TOKEN }}
     - name: Pull AMD image
       run: |
-        docker pull --platform linux/amd64 $DOCKER_BUILD_REPOSITORY:${{ matrix.image }}-amd64-$SHORT_SHA
-        docker tag $DOCKER_BUILD_REPOSITORY:${{ matrix.image }}-amd64-$SHORT_SHA $DOCKER_BUILD_REPOSITORY:${{ matrix.image }}-amd64
+        docker pull --platform linux/amd64 $DOCKER_BUILD_REPOSITORY:${{ matrix.image }}-amd64-${{ env.SHORT_SHA }}
+        docker tag $DOCKER_BUILD_REPOSITORY:${{ matrix.image }}-amd64-${{ env.SHORT_SHA }} $DOCKER_BUILD_REPOSITORY:${{ matrix.image }}-amd64
         docker push $DOCKER_BUILD_REPOSITORY:${{ matrix.image }}-amd64
     - name: Pull ARM image
       run: |
-        docker pull --platform linux/arm64 $DOCKER_BUILD_REPOSITORY:${{ matrix.image }}-arm64-$SHORT_SHA
-        docker tag $DOCKER_BUILD_REPOSITORY:${{ matrix.image }}-arm64-$SHORT_SHA $DOCKER_BUILD_REPOSITORY:${{ matrix.image }}-arm64
+        docker pull --platform linux/arm64 $DOCKER_BUILD_REPOSITORY:${{ matrix.image }}-arm64-${{ env.SHORT_SHA }}
+        docker tag $DOCKER_BUILD_REPOSITORY:${{ matrix.image }}-arm64-${{ env.SHORT_SHA }} $DOCKER_BUILD_REPOSITORY:${{ matrix.image }}-arm64
         docker push $DOCKER_BUILD_REPOSITORY:${{ matrix.image }}-arm64
     - name: Push multiarch manifest with short SHA
       env:
-        IMAGE_TAG: ${{ matrix.image }}-$SHORT_SHA
+        IMAGE_TAG: ${{ matrix.image }}-${{ env.SHORT_SHA }}
       run: |
         docker manifest create $DOCKER_REPOSITORY/$DOCKER_IMAGE:${IMAGE_TAG} $DOCKER_BUILD_REPOSITORY:${{ matrix.image }}-amd64 $DOCKER_BUILD_REPOSITORY:${{ matrix.image }}-arm64
         docker manifest push $DOCKER_REPOSITORY/$DOCKER_IMAGE:${IMAGE_TAG}

--- a/dockerfiles/wolfi-base/Dockerfile
+++ b/dockerfiles/wolfi-base/Dockerfile
@@ -5,7 +5,9 @@ COPY ./scripts/install-wolfi-libreoffice.sh install-wolfi-libreoffice.sh
 COPY ./scripts/install-wolfi-tesseract.sh install-wolfi-tesseract.sh
 
 USER root
-RUN apk update && apk add py3.11-pip mesa-gl glib cmake bash libmagic wget openjpeg && \
+RUN apk update && \
+    apk del python-3.12 && \
+    apk add py3.11-pip mesa-gl glib cmake bash libmagic wget openjpeg && \
     apk add --allow-untrusted packages/pandoc-3.1.8-r0.apk && \
     apk add --allow-untrusted packages/poppler-23.09.0-r0.apk && \
     ./install-wolfi-tesseract.sh && rm install-wolfi-tesseract.sh && \

--- a/scripts/docker-dl-wolfi-packages.sh
+++ b/scripts/docker-dl-wolfi-packages.sh
@@ -10,6 +10,7 @@ else
   files=(
     "poppler-23.09.0-r0.apk"
     "pandoc-3.1.8-r0.apk"
+    "libreoffice-7.6.5-r0.apk"
     "nltk_data.tgz"
   )
 fi

--- a/scripts/initialize-libreoffice.sh
+++ b/scripts/initialize-libreoffice.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
 
+ARCH=$(uname -m)
+
 /usr/bin/soffice --headless || [ $? -eq 81 ] || exit 1

--- a/scripts/initialize-libreoffice.sh
+++ b/scripts/initialize-libreoffice.sh
@@ -1,5 +1,3 @@
 #!/bin/bash
 
-ARCH=$(uname -m)
-
 /usr/bin/soffice --headless || [ $? -eq 81 ] || exit 1

--- a/scripts/install-wolfi-libreoffice.sh
+++ b/scripts/install-wolfi-libreoffice.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-RCH=$(uname -m)
+ARCH=$(uname -m)
 
 if [[ "$ARCH" == "x86_64" ]] || [[ "$ARCH" == "amd64" ]]; then
   apk add --allow-untrusted packages/libreoffice-7.6.5-r0.apk

--- a/scripts/install-wolfi-libreoffice.sh
+++ b/scripts/install-wolfi-libreoffice.sh
@@ -1,8 +1,19 @@
 #!/bin/bash
 
-apk add libreoffice
-ln -s /usr/lib/libreoffice/program/soffice.bin /usr/bin/libreoffice
-ln -s /usr/lib/libreoffice/program/soffice.bin /usr/bin/soffice
-chmod +x /usr/lib/libreoffice/program/soffice.bin
-chmod +x /usr/bin/libreoffice
-chmod +x /usr/bin/soffice
+RCH=$(uname -m)
+
+if [[ "$ARCH" == "x86_64" ]] || [[ "$ARCH" == "amd64" ]]; then
+  apk add --allow-untrusted packages/libreoffice-7.6.5-r0.apk
+  ln -s /usr/local/lib/libreoffice/program/soffice.bin /usr/bin/libreoffice
+  ln -s /usr/local/lib/libreoffice/program/soffice.bin /usr/bin/soffice
+  chmod +x /usr/local/lib/libreoffice/program/soffice.bin
+  chmod +x /usr/bin/libreoffice
+  chmod +x /usr/bin/soffice
+else
+  apk add libreoffice
+  ln -s /usr/lib/libreoffice/program/soffice.bin /usr/bin/libreoffice
+  ln -s /usr/lib/libreoffice/program/soffice.bin /usr/bin/soffice
+  chmod +x /usr/lib/libreoffice/program/soffice.bin
+  chmod +x /usr/bin/libreoffice
+  chmod +x /usr/bin/soffice
+fi


### PR DESCRIPTION
###  Summary

Per test failures on [this PR](https://github.com/Unstructured-IO/unstructured/pull/3310) in `unstructured`, the `libreoffice24` installation from the `wolfi-os` package manager does not convert `.ppt` files (though it does convert `.doc` files). This PR reverts to `libreoffice7` for the `amd64` image to avoid dropping support for `.ppt` in the `amd64` image. `libreoffice24` is still installed for the `arm64` image because that allows us to support one additional doc type (`.doc`) in the `arm64` `unsturcutred` image. We don't have a `libreoffice7` build currently for `arm64`.

Next steps on this are to try and debug why `libreoffice24` doesn't convert `.ppt`. Note that per [this PR](https://github.com/Unstructured-IO/base-images/pull/25), `libreoffice24` from the `wolfi` package manager previously converted `.ppt` files, and it is likely that we can fix this by tweaking the `libreoffice24` build.
