### PR TITLE
build(CVE-2024-6472): bump to `libreoffice-24.2.5.2`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
         with:
           image: "${{ env.DOCKER_BUILD_REPOSITORY }}:${{ matrix.image }}-${{ matrix.architecture }}-${{ env.SHORT_SHA }}"
           severity-cutoff: high
-          fail-build: ${{ matrix.image == 'wolfi-base' }} # || matrix.image == "wolfi-py3.12-slim" }}
+          fail-build: ${{ ( matrix.image == 'wolfi-base' || matrix.image == 'wolfi-py3.12-slim' ) }}
           output-format: table
 
   publish-images:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
         with:
           image: "${{ env.DOCKER_BUILD_REPOSITORY }}:${{ matrix.image }}-${{ matrix.architecture }}-${{ env.SHORT_SHA }}"
           severity-cutoff: high
-          fail-build: ${{ matrix.image == 'wolfi-base' || matrix.image == "wolfi-py3.12-slim" }}
+          fail-build: ${{ matrix.image == 'wolfi-base' }} # || matrix.image == "wolfi-py3.12-slim" }}
           output-format: table
 
   publish-images:

--- a/dockerfiles/wolfi-base/Dockerfile
+++ b/dockerfiles/wolfi-base/Dockerfile
@@ -7,7 +7,7 @@ COPY ./scripts/install-wolfi-tesseract.sh install-wolfi-tesseract.sh
 USER root
 RUN apk update && \
     apk del python-3.12 && \
-    apk add py3.11-pip boost mesa-gl glib cmake bash libmagic wget openjpeg && \
+    apk add py3.11-pip libcmis-dev mesa-gl glib cmake bash libmagic wget openjpeg && \
     apk add --allow-untrusted packages/pandoc-3.1.8-r0.apk && \
     apk add --allow-untrusted packages/poppler-23.09.0-r0.apk && \
     ./install-wolfi-tesseract.sh && rm install-wolfi-tesseract.sh && \

--- a/dockerfiles/wolfi-base/Dockerfile
+++ b/dockerfiles/wolfi-base/Dockerfile
@@ -7,7 +7,7 @@ COPY ./scripts/install-wolfi-tesseract.sh install-wolfi-tesseract.sh
 USER root
 RUN apk update && \
     apk del python-3.12 && \
-    apk del libcmis-dev && \
+    apk del libcmis && \
     apk add py3.11-pip mesa-gl glib cmake bash libmagic wget openjpeg && \
     apk add --allow-untrusted packages/pandoc-3.1.8-r0.apk && \
     apk add --allow-untrusted packages/poppler-23.09.0-r0.apk && \

--- a/dockerfiles/wolfi-base/Dockerfile
+++ b/dockerfiles/wolfi-base/Dockerfile
@@ -7,6 +7,7 @@ COPY ./scripts/install-wolfi-tesseract.sh install-wolfi-tesseract.sh
 USER root
 RUN apk update && \
     apk del python-3.12 && \
+    apk del libcmis-dev && \
     apk add py3.11-pip mesa-gl glib cmake bash libmagic wget openjpeg && \
     apk add --allow-untrusted packages/pandoc-3.1.8-r0.apk && \
     apk add --allow-untrusted packages/poppler-23.09.0-r0.apk && \

--- a/dockerfiles/wolfi-base/Dockerfile
+++ b/dockerfiles/wolfi-base/Dockerfile
@@ -7,7 +7,6 @@ COPY ./scripts/install-wolfi-tesseract.sh install-wolfi-tesseract.sh
 USER root
 RUN apk update && \
     apk del python-3.12 && \
-    apk del libcmis && \
     apk add py3.11-pip mesa-gl glib cmake bash libmagic wget openjpeg && \
     apk add --allow-untrusted packages/pandoc-3.1.8-r0.apk && \
     apk add --allow-untrusted packages/poppler-23.09.0-r0.apk && \

--- a/dockerfiles/wolfi-base/Dockerfile
+++ b/dockerfiles/wolfi-base/Dockerfile
@@ -7,7 +7,7 @@ COPY ./scripts/install-wolfi-tesseract.sh install-wolfi-tesseract.sh
 USER root
 RUN apk update && \
     apk del python-3.12 && \
-    apk add py3.11-pip libcmis-dev mesa-gl glib cmake bash libmagic wget openjpeg && \
+    apk add py3.11-pip mesa-gl glib cmake bash libmagic wget openjpeg && \
     apk add --allow-untrusted packages/pandoc-3.1.8-r0.apk && \
     apk add --allow-untrusted packages/poppler-23.09.0-r0.apk && \
     ./install-wolfi-tesseract.sh && rm install-wolfi-tesseract.sh && \

--- a/dockerfiles/wolfi-base/Dockerfile
+++ b/dockerfiles/wolfi-base/Dockerfile
@@ -7,7 +7,7 @@ COPY ./scripts/install-wolfi-tesseract.sh install-wolfi-tesseract.sh
 USER root
 RUN apk update && \
     apk del python-3.12 && \
-    apk add py3.11-pip mesa-gl glib cmake bash libmagic wget openjpeg && \
+    apk add py3.11-pip boost mesa-gl glib cmake bash libmagic wget openjpeg && \
     apk add --allow-untrusted packages/pandoc-3.1.8-r0.apk && \
     apk add --allow-untrusted packages/poppler-23.09.0-r0.apk && \
     ./install-wolfi-tesseract.sh && rm install-wolfi-tesseract.sh && \

--- a/melange/libreoffice-24.yaml
+++ b/melange/libreoffice-24.yaml
@@ -126,6 +126,7 @@ pipeline:
       --with-jdk-home=$JAVA_HOME
       --enable-python=system
       --enable-split-debug
+      --disable-libcmis
       --prefix=/usr
       --with-system-argon2
       --with-system-libcmis

--- a/melange/libreoffice-24.yaml
+++ b/melange/libreoffice-24.yaml
@@ -19,7 +19,6 @@ package:
       - freetype
       - glib
       - gpgme
-      - libcmis-dev
       - libcurl-openssl4
       - libfontconfig1
       - liblangtag
@@ -79,6 +78,7 @@ environment:
       - liblangtag-dev
       - libnspr-dev
       - libnss-dev
+      - libpsl-dev
       - libsm-dev
       - libtool
       - libx11-dev
@@ -97,6 +97,7 @@ environment:
       - mesa-egl
       - mesa-gl
       - nasm
+      - nghttp2-dev
       - openjdk-17
       - openjdk-17-default-jvm
       - openssl-dev
@@ -109,6 +110,9 @@ environment:
       - python-3.11
       - python-3.11-dev
       - zip
+  environment:
+    JAVA_HOME: /usr/lib/jvm/java-17-openjdk
+
 
 pipeline:
   - uses: git-checkout
@@ -119,11 +123,12 @@ pipeline:
 
   - runs: |
       cat > autogen.input <<EOF
+      --with-jdk-home=$JAVA_HOME
       --enable-python=system
       --enable-split-debug
       --prefix=/usr
       --with-system-argon2
-      # --with-system-libcmis
+      --with-system-libcmis
       --with-system-expat
       --with-system-gpgmepp
       --with-system-liblangtag
@@ -131,7 +136,7 @@ pipeline:
       --with-system-cairo
       --with-system-zlib
       --with-system-boost
-      # --with-system-curl
+      --with-system-curl
       --disable-gui
       --disable-cups
       --disable-lotuswordpro
@@ -170,6 +175,7 @@ update:
     identifier: LibreOffice/core
     use-tag: true
     strip-prefix: libreoffice-
+    tag-filter-prefix: libreoffice-24
 
 test:
   environment:

--- a/melange/libreoffice-24.yaml
+++ b/melange/libreoffice-24.yaml
@@ -1,6 +1,6 @@
 package:
   name: libreoffice-24
-  version: 24.2.3.2
+  version: 24.2.5.2
   epoch: 1
   description:
   # https://www.libreoffice.org/about-us/licenses
@@ -19,6 +19,7 @@ package:
       - freetype
       - glib
       - gpgme
+      - libcmis-dev
       - libcurl-openssl4
       - libfontconfig1
       - liblangtag
@@ -114,7 +115,7 @@ pipeline:
     with:
       repository: https://github.com/LibreOffice/core
       tag: libreoffice-${{package.version}}
-      expected-commit: 433d9c2ded56988e8a90e6b2e771ee4e6a5ab2ba
+      expected-commit: bffef4ea93e59bebbeaf7f431bb02b1a39ee8a59
 
   - runs: |
       cat > autogen.input <<EOF
@@ -122,7 +123,7 @@ pipeline:
       --enable-split-debug
       --prefix=/usr
       --with-system-argon2
-      --with-system-libcmis
+      # --with-system-libcmis
       --with-system-expat
       --with-system-gpgmepp
       --with-system-liblangtag
@@ -130,7 +131,7 @@ pipeline:
       --with-system-cairo
       --with-system-zlib
       --with-system-boost
-      --with-system-curl
+      # --with-system-curl
       --disable-gui
       --disable-cups
       --disable-lotuswordpro

--- a/scripts/docker-dl-wolfi-packages.sh
+++ b/scripts/docker-dl-wolfi-packages.sh
@@ -4,14 +4,14 @@ if [ "$ARCH" = "arm64" ] || [ "$ARCH" = "aarch64" ]; then
   files=(
     "poppler-23.09.0-r0-aarch64.apk"
     "pandoc-3.1.8-r0-aarch64.apk"
-    "libreoffice-24-24.2.3.2-r1-aarch64.apk"
+    "libreoffice-24-24.2.5.2-r1-aarch64.apk"
     "nltk_data.tgz"
   )
 else
   files=(
     "poppler-23.09.0-r0.apk"
     "pandoc-3.1.8-r0.apk"
-    "libreoffice-24-24.2.3.2-r1.apk"
+    "libreoffice-24-24.2.5.2-r1.apk"
     "nltk_data.tgz"
   )
 fi

--- a/scripts/install-wolfi-libreoffice.sh
+++ b/scripts/install-wolfi-libreoffice.sh
@@ -2,8 +2,8 @@
 
 apk add --allow-untrusted packages/libreoffice-24-24.2.5.2-r1.apk
 
-ln -s /usr/local/lib/libreoffice/program/soffice.bin /usr/bin/libreoffice && \
-ln -s /usr/local/lib/libreoffice/program/soffice.bin /usr/bin/soffice && \
-chmod +x /usr/local/lib/libreoffice/program/soffice.bin && \
-chmod +x /usr/bin/libreoffice
+ln -s /usr/local/lib/libreoffice/program/soffice.bin /usr/bin/libreoffice &&
+  ln -s /usr/local/lib/libreoffice/program/soffice.bin /usr/bin/soffice &&
+  chmod +x /usr/local/lib/libreoffice/program/soffice.bin &&
+  chmod +x /usr/bin/libreoffice
 chmod +x /usr/bin/soffice

--- a/scripts/install-wolfi-libreoffice.sh
+++ b/scripts/install-wolfi-libreoffice.sh
@@ -2,8 +2,8 @@
 
 apk add --allow-untrusted packages/libreoffice-24-24.2.5.2-r1.apk
 
-ln -s /usr/lib/libreoffice/program/soffice.bin /usr/bin/libreoffice
-ln -s /usr/lib/libreoffice/program/soffice.bin /usr/bin/soffice
-chmod +x /usr/lib/libreoffice/program/soffice.bin
+ln -s /usr/local/lib/libreoffice/program/soffice.bin /usr/bin/libreoffice && \
+ln -s /usr/local/lib/libreoffice/program/soffice.bin /usr/bin/soffice && \
+chmod +x /usr/local/lib/libreoffice/program/soffice.bin && \
 chmod +x /usr/bin/libreoffice
 chmod +x /usr/bin/soffice

--- a/scripts/install-wolfi-libreoffice.sh
+++ b/scripts/install-wolfi-libreoffice.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-apk add --allow-untrusted packages/libreoffice-24-24.2.3.2-r1.apk
+apk add --allow-untrusted packages/libreoffice-24-24.2.5.2-r1.apk
 
 ln -s /usr/lib/libreoffice/program/soffice.bin /usr/bin/libreoffice
 ln -s /usr/lib/libreoffice/program/soffice.bin /usr/bin/soffice

--- a/scripts/install-wolfi-libreoffice.sh
+++ b/scripts/install-wolfi-libreoffice.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
-apk add --allow-untrusted packages/libreoffice-24-24.2.5.2-r1.apk
+apk add --allow-untrusted packages/libreoffice-24-24.2.3.2-r1.apk
 
-ln -s /usr/local/lib/libreoffice/program/soffice.bin /usr/bin/libreoffice &&
-  ln -s /usr/local/lib/libreoffice/program/soffice.bin /usr/bin/soffice &&
-  chmod +x /usr/local/lib/libreoffice/program/soffice.bin &&
-  chmod +x /usr/bin/libreoffice
+ln -s /usr/lib/libreoffice/program/soffice.bin /usr/bin/libreoffice
+ln -s /usr/lib/libreoffice/program/soffice.bin /usr/bin/soffice
+chmod +x /usr/lib/libreoffice/program/soffice.bin
+chmod +x /usr/bin/libreoffice
 chmod +x /usr/bin/soffice


### PR DESCRIPTION
###  Summary

Bumps to `libreoffice-24.2.5.2` to address [CVE-2024-6472](https://www.libreoffice.org/about-us/security/advisories/CVE-2024-6472).

### Test instructions

Image build should succeed with the update image. Additionally, @amadeusz-ds tested the updated APK with the API image.