### PR TITLE
add additional packages to wolfi-base

### DIFF
--- a/dockerfiles/wolfi-base/Dockerfile
+++ b/dockerfiles/wolfi-base/Dockerfile
@@ -7,7 +7,7 @@ COPY ./scripts/install-wolfi-tesseract.sh install-wolfi-tesseract.sh
 USER root
 RUN apk update && \
     apk del python-3.12 && \
-    apk add py3.11-pip mesa-gl glib cmake bash libmagic wget openjpeg && \
+    apk add py3.11-pip python-3.11-dev mesa-gl glib glibc-dev cmake bash libmagic wget git openjpeg && \
     apk add --allow-untrusted packages/pandoc-3.1.8-r0.apk && \
     apk add --allow-untrusted packages/poppler-23.09.0-r0.apk && \
     ./install-wolfi-tesseract.sh && rm install-wolfi-tesseract.sh && \

--- a/dockerfiles/wolfi-base/Dockerfile
+++ b/dockerfiles/wolfi-base/Dockerfile
@@ -7,7 +7,7 @@ COPY ./scripts/install-wolfi-tesseract.sh install-wolfi-tesseract.sh
 USER root
 RUN apk update && \
     apk del python-3.12 && \
-    apk add py3.11-pip python-3.11-dev mesa-gl glib glibc-dev cmake bash libmagic wget git openjpeg && \
+    apk add py3.11-pip mesa-gl glib cmake bash libmagic wget git openjpeg && \
     apk add --allow-untrusted packages/pandoc-3.1.8-r0.apk && \
     apk add --allow-untrusted packages/poppler-23.09.0-r0.apk && \
     ./install-wolfi-tesseract.sh && rm install-wolfi-tesseract.sh && \


### PR DESCRIPTION
###  Summary

This PR addresses the following issues:

- add `python-3.11-dev` and `glibc-dev` packages, which are necessary for installing the `lanms-neo` dependency required by `PaddleOCR`.
- add `git` package to enable installation of the latest version of `pytesseract` directly from the git source, as introduced in PR https://github.com/Unstructured-IO/unstructured/pull/3454/files#diff-c45ceb0e2d6f3f2b79349b98f8cf6002f8ac0aaf5e70afd8cf395eafc1c07f96R26.