### PR TITLE
build: epoch2 for libreoffice 25.2.5

### DIFF
--- a/melange/libreoffice-24.yaml
+++ b/melange/libreoffice-24.yaml
@@ -1,7 +1,7 @@
 package:
   name: libreoffice-24
   version: 24.2.5.2
-  epoch: 1
+  epoch: 2
   description:
   # https://www.libreoffice.org/about-us/licenses
   copyright:


### PR DESCRIPTION
###  Summary

Rebuilds `libreoffice 25.2.5` using the latest dependencies available from `wolfi-os`.

