### PR TITLE
build: add python 3.12 to wolfi-base

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,8 +25,8 @@ jobs:
     strategy:
       matrix:
         architecture: ["arm64", "amd64"]
-        # NOTE(robinson) - temporarily disabled rocky9.2-gpu
-        image: ["wolfi-base", "wolfi-py3.12-slim", "rocky9.2-slim", "rocky9.2-cpu"]
+        # NOTE(robinson) - temporarily disabled rocky due to build failures
+        image: ["wolfi-base", "wolfi-py3.12-slim"] # ["rocky9.2-gpu", "rocky9.2-slim", "rocky9.2-cpu"]
     runs-on: ubuntu-latest-m
     needs: [set-short-sha]
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,8 @@ jobs:
     strategy:
       matrix:
         architecture: ["arm64", "amd64"]
-        image: ["wolfi-base", "wolfi-py3.12-slim", "rocky9.2-gpu", "rocky9.2-slim", "rocky9.2-cpu"]
+        # NOTE(robinson) - temporarily disabled rocky9.2-gpu
+        image: ["wolfi-base", "wolfi-py3.12-slim", "rocky9.2-slim", "rocky9.2-cpu"]
     runs-on: ubuntu-latest-m
     needs: [set-short-sha]
     env:

--- a/dockerfiles/wolfi-base/Dockerfile
+++ b/dockerfiles/wolfi-base/Dockerfile
@@ -6,7 +6,7 @@ COPY ./scripts/install-wolfi-tesseract.sh install-wolfi-tesseract.sh
 
 USER root
 RUN apk update && \
-    apk add py3.11-pip py3.12-pip mesa-gl glib cmake bash libmagic wget git openjpeg && \
+    apk add py3.12-pip mesa-gl glib cmake bash libmagic wget git openjpeg && \
     apk add --allow-untrusted packages/pandoc-3.1.8-r0.apk && \
     apk add --allow-untrusted packages/poppler-23.09.0-r0.apk && \
     ./install-wolfi-tesseract.sh && rm install-wolfi-tesseract.sh && \

--- a/dockerfiles/wolfi-base/Dockerfile
+++ b/dockerfiles/wolfi-base/Dockerfile
@@ -6,7 +6,7 @@ COPY ./scripts/install-wolfi-tesseract.sh install-wolfi-tesseract.sh
 
 USER root
 RUN apk update && \
-    apk add py3.11-pip mesa-gl glib cmake bash libmagic wget git openjpeg && \
+    apk add py3.11-pip py3.12-pip mesa-gl glib cmake bash libmagic wget git openjpeg && \
     apk add --allow-untrusted packages/pandoc-3.1.8-r0.apk && \
     apk add --allow-untrusted packages/poppler-23.09.0-r0.apk && \
     ./install-wolfi-tesseract.sh && rm install-wolfi-tesseract.sh && \

--- a/dockerfiles/wolfi-base/Dockerfile
+++ b/dockerfiles/wolfi-base/Dockerfile
@@ -6,7 +6,6 @@ COPY ./scripts/install-wolfi-tesseract.sh install-wolfi-tesseract.sh
 
 USER root
 RUN apk update && \
-    apk del python-3.12 && \
     apk add py3.11-pip mesa-gl glib cmake bash libmagic wget git openjpeg && \
     apk add --allow-untrusted packages/pandoc-3.1.8-r0.apk && \
     apk add --allow-untrusted packages/poppler-23.09.0-r0.apk && \

--- a/dockerfiles/wolfi-base/Dockerfile
+++ b/dockerfiles/wolfi-base/Dockerfile
@@ -6,7 +6,7 @@ COPY ./scripts/install-wolfi-tesseract.sh install-wolfi-tesseract.sh
 
 USER root
 RUN apk update && \
-    apk add py3.12-pip mesa-gl glib cmake bash libmagic wget git openjpeg && \
+    apk add py3.11-pip mesa-gl glib cmake bash libmagic wget git openjpeg && \
     apk add --allow-untrusted packages/pandoc-3.1.8-r0.apk && \
     apk add --allow-untrusted packages/poppler-23.09.0-r0.apk && \
     ./install-wolfi-tesseract.sh && rm install-wolfi-tesseract.sh && \


### PR DESCRIPTION
###  Summary

Adds Python 3.12 to `wolfi-base` to support bumping the `unstructured` and `unstructured-api` images to the 3.12. This PR also temporarily disables the rocky builds because failures in those jobs were blocking the wolfi builds.

