### PR TITLE
fix: install mesa-gl 24.1.0 due to libgallium missing

### DIFF
--- a/dockerfiles/wolfi-base/Dockerfile
+++ b/dockerfiles/wolfi-base/Dockerfile
@@ -5,8 +5,16 @@ COPY ./scripts/install-wolfi-libreoffice.sh install-wolfi-libreoffice.sh
 COPY ./scripts/install-wolfi-tesseract.sh install-wolfi-tesseract.sh
 
 USER root
+# NOTE(robinson) - the mesa-gl section is a temporary workaround to install mesa-gl 24.1.0 because
+# libgallum is missing in mesa-gl 24.2.0 from the wolfi package manager
 RUN apk update && \
-    apk add py3.11-pip mesa-gl glib cmake bash libmagic wget git openjpeg && \
+    apk add py3.11-pip glib cmake bash libmagic wget git openjpeg && \
+    wget "https://utic-public-cf.s3.amazonaws.com/mesa-gl-24.1.0-r0.718c913d.apk" && \
+    wget "https://utic-public-cf.s3.amazonaws.com/mesa-glapi-24.1.0-r0.4390a503.apk" && \
+    apk add --allow-untrusted mesa-gl-24.1.0-r0.718c913d.apk && \
+    apk add --allow-untrusted mesa-glapi-24.1.0-r0.4390a503.apk && \
+    rm mesa-gl-24.1.0-r0.718c913d.apk && \
+    rm mesa-glapi-24.1.0-r0.4390a503.apk && \
     apk add --allow-untrusted packages/pandoc-3.1.8-r0.apk && \
     apk add --allow-untrusted packages/poppler-23.09.0-r0.apk && \
     ./install-wolfi-tesseract.sh && rm install-wolfi-tesseract.sh && \


### PR DESCRIPTION
###  Summary

Upstreams a temporary workaround to install `mesa-gl==24.1.0` because `libgallium` is missing from `mesa-gl==24.2.0` in the `wolfi` package manager. This was causing build errors in jobs like [this one](https://github.com/Unstructured-IO/core-product/actions/runs/10781356425/job/29899112925?pr=605).

```
 > [model-deps 4/4] RUN --mount=type=secret,id=hf_token,uid=1000   export UNSTRUCTURED_HF_TOKEN=$(cat /run/secrets/hf_token) || true;   ./scripts/preload-models.sh:
9.719   File "/home/notebook-user/unstructured/unstructured/partition/utils/ocr_models/paddle_ocr.py", line 23, in __init__
9.719     self.agent = self.load_agent(language)
9.719                  ^^^^^^^^^^^^^^^^^^^^^^^^^
9.719   File "/home/notebook-user/unstructured/unstructured/partition/utils/ocr_models/paddle_ocr.py", line 29, in load_agent
9.719     from unstructured_paddleocr import PaddleOCR
9.719   File "/home/notebook-user/.local/lib/python3.11/site-packages/unstructured_paddleocr/__init__.py", line 14, in <module>
9.719     from .paddleocr import *
9.719   File "/home/notebook-user/.local/lib/python3.11/site-packages/unstructured_paddleocr/paddleocr.py", line 26, in <module>
9.719     import cv2
9.719 ImportError: libgallium-24.2.2.so: cannot open shared object file: No such file or directory
```

