### PR TITLE
build: add `melange` config for `libpst`

### DIFF
--- a/melange/libpst.yaml
+++ b/melange/libpst.yaml
@@ -1,0 +1,63 @@
+package:
+  name: libpst
+  version: 0.6.76
+  description: library for reading Microsoft Outlook PST files
+  target-architecture:
+    - x86_64
+  copyright:
+    - license: GPL-2.0
+      paths:
+        - "*"
+
+environment:
+  contents:
+    repositories:
+      - https://packages.wolfi.dev/os
+    keyring:
+      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    packages:
+      - autoconf
+      - automake
+      - bash
+      - boost-dev
+      - build-base
+      - ca-certificates
+      - coreutils
+      - cmake
+      - gcc
+      - gcc-6
+      - gettext-dev
+      - gnutar
+      - gobject-introspection-dev
+      - glib-dev
+      - gzip
+      - libgsf-dev
+      - libtool
+      - libxml2-dev
+      - make
+      - pkgconf-dev
+      # - python-3-dev
+      # - py3-pip
+      # - py3-pip-wheel
+      - wolfi-base
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://github.com/pst-format/libpst/archive/refs/tags/libpst-${{package.version}}.tar.gz
+      expected-sha256: 2ed22fcb8c3f9b99ab131231149b4f0958730b5f265b423c26a4b43f36344dcc
+  - runs: |
+      tar -xzf libpst-${{package.version}}.tar.gz
+      cd libpst-libpst-${{package.version}}
+
+      mkdir -p ${{targets.destdir}}/usr/local
+
+      touch man/readpst.1 man/pst2ldif.1 man/lspst.1 man/outlook.pst.5 man/pst2dii.1
+      # pip install setuptools
+
+      # ln -s /usr/include/python3.12/pyconfig.h /usr/include/boost/python/pyconfig.h
+      autoreconf -fi
+      /bin/bash configure --enable-python=no
+      make
+      su
+      make install DESTDIR="${{targets.destdir}}"

--- a/melange/libpst.yaml
+++ b/melange/libpst.yaml
@@ -36,9 +36,6 @@ environment:
       - libxml2-dev
       - make
       - pkgconf-dev
-      # - python-3-dev
-      # - py3-pip
-      # - py3-pip-wheel
       - wolfi-base
 
 pipeline:
@@ -52,10 +49,10 @@ pipeline:
 
       mkdir -p ${{targets.destdir}}/usr/local
 
+      # NOTE(robinson) - the files for the man pages were missing. Here we're just creating
+      # dummy man page files to enable the build to succeed.
       touch man/readpst.1 man/pst2ldif.1 man/lspst.1 man/outlook.pst.5 man/pst2dii.1
-      # pip install setuptools
 
-      # ln -s /usr/include/python3.12/pyconfig.h /usr/include/boost/python/pyconfig.h
       autoreconf -fi
       /bin/bash configure --enable-python=no
       make


### PR DESCRIPTION
###  Summary

Adds the melange config to build `libpst` for `wolfi-base`. The pipeline builds the CLI package, but not the Python bindings and the build pipeline does not include the man pages. Build has only been tested on `x86_64`.

### Test instructions

To build the packages, run:

```
docker run --privleged --rm \
    -v "${PWD}":/work \
    cgr.dev/chainguard/melange \
    build libpst.yaml \
    --arch=x86_64 \
    --signing-key melange.rsa
```

After the package is built, install it in `wolfi-base` with:

```
apk add --allow-untrusted libpst-0.6.76-r0.apk
```

Once it's installed, verify that `readpst` is available by runnign `readpst --help`.