### PR TITLE
fix: add `arm64` package for `mesa-gl`

### DIFF
--- a/dockerfiles/wolfi-base/Dockerfile
+++ b/dockerfiles/wolfi-base/Dockerfile
@@ -9,12 +9,7 @@ USER root
 # libgallum is missing in mesa-gl 24.2.0 from the wolfi package manager
 RUN apk update && \
     apk add py3.11-pip glib cmake bash libmagic wget git openjpeg && \
-    wget "https://utic-public-cf.s3.amazonaws.com/mesa-gl-24.1.0-r0.718c913d.apk" && \
-    wget "https://utic-public-cf.s3.amazonaws.com/mesa-glapi-24.1.0-r0.4390a503.apk" && \
-    apk add --allow-untrusted mesa-gl-24.1.0-r0.718c913d.apk && \
-    apk add --allow-untrusted mesa-glapi-24.1.0-r0.4390a503.apk && \
-    rm mesa-gl-24.1.0-r0.718c913d.apk && \
-    rm mesa-glapi-24.1.0-r0.4390a503.apk && \
+    ./install-wolfi-mesa-gl.sh && \
     apk add --allow-untrusted packages/pandoc-3.1.8-r0.apk && \
     apk add --allow-untrusted packages/poppler-23.09.0-r0.apk && \
     ./install-wolfi-tesseract.sh && rm install-wolfi-tesseract.sh && \

--- a/dockerfiles/wolfi-base/Dockerfile
+++ b/dockerfiles/wolfi-base/Dockerfile
@@ -3,13 +3,14 @@ FROM cgr.dev/chainguard/wolfi-base:latest
 COPY ./docker-packages/*.apk packages/
 COPY ./scripts/install-wolfi-libreoffice.sh install-wolfi-libreoffice.sh
 COPY ./scripts/install-wolfi-tesseract.sh install-wolfi-tesseract.sh
+COPY ./scripts/install-wolfi-mesa-gl.sh install-wolfi-mesa-gl.sh
 
 USER root
 # NOTE(robinson) - the mesa-gl section is a temporary workaround to install mesa-gl 24.1.0 because
 # libgallum is missing in mesa-gl 24.2.0 from the wolfi package manager
 RUN apk update && \
     apk add py3.11-pip glib cmake bash libmagic wget git openjpeg && \
-    ./install-wolfi-mesa-gl.sh && \
+    ./install-wolfi-mesa-gl.sh && rm install-wolfi-mesa-gl.sh && \
     apk add --allow-untrusted packages/pandoc-3.1.8-r0.apk && \
     apk add --allow-untrusted packages/poppler-23.09.0-r0.apk && \
     ./install-wolfi-tesseract.sh && rm install-wolfi-tesseract.sh && \

--- a/melange/mesa.yaml
+++ b/melange/mesa.yaml
@@ -1,0 +1,143 @@
+package:
+  name: mesa
+  version: 24.1.0
+  epoch: 0
+  description: Mesa DRI OpenGL library
+  target-architecture:
+    - aarch64
+  copyright:
+    - license: MIT AND SGI-B-2.0 AND BSL-1.0
+
+environment:
+  contents:
+    repositories:
+      - https://packages.wolfi.dev/os
+    keyring:
+      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    packages:
+      - autoconf
+      - automake
+      - bison
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - elfutils-dev
+      - eudev-dev
+      - expat-dev
+      - findutils
+      - flex
+      - gettext
+      - glslang-dev
+      - libdrm-dev
+      - libtool
+      - libva
+      - libva-dev
+      - libvdpau-dev
+      - libx11-dev
+      - libxcb-dev
+      - libxdamage-dev
+      - libxext-dev
+      - libxfixes-dev
+      - libxml2-dev
+      - libxrandr
+      - libxrandr-dev
+      - libxrender
+      - libxrender-dev
+      - libxshmfence-dev
+      - libxxf86vm-dev
+      - llvm16
+      - llvm16-dev
+      - meson
+      - py3-mako
+      - py3-markupsafe
+      - py3-pygments
+      - py3-setuptools
+      - python3
+      - vulkan-loader
+      - wayland-dev
+      - wayland-protocols
+      - xorgproto
+      - zlib-dev
+      - zstd-dev
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: b7eac8c79244806b1c276eeeacc329e4a5b31a370804c4b0c7cd16837783f78b
+      uri: https://mesa.freedesktop.org/archive/mesa-${{package.version}}.tar.xz
+
+  - runs: |
+      export CFLAGS="$CFLAGS -O2 -g1"
+      export CXXFLAGS="$CXXFLAGS -O2 -g1"
+      export CPPFLAGS="$CPPFLAGS -O2 -g1"
+
+      _dri_driverdir=/usr/lib/xorg/modules/dri
+      _gallium_drivers="r300,r600,radeonsi,nouveau,swrast,virgl,zink"
+      _vulkan_drivers="amd,swrast"
+      _vulkan_layers="device-select,overlay"
+
+      PATH="$PATH:/usr/lib/llvm$_llvmver/bin" \
+      meson \
+        --prefix=/usr \
+        -Ddri-drivers-path=$_dri_driverdir \
+        -Dgallium-drivers=$_gallium_drivers \
+        -Dvulkan-drivers=$_vulkan_drivers \
+        -Dvulkan-layers=$_vulkan_layers \
+        -Dplatforms=x11,wayland \
+        -Dllvm=enabled \
+        -Dshared-llvm=enabled \
+        -Dshared-glapi=enabled \
+        -Dgbm=enabled \
+        -Dglx=dri \
+        -Dopengl=true \
+        -Dosmesa=true \
+        -Dgles1=enabled \
+        -Dgles2=enabled \
+        -Degl=enabled \
+        -Dgallium-extra-hud=true \
+        -Dgallium-xa=enabled \
+        -Dgallium-vdpau=enabled \
+        -Dgallium-va=enabled \
+        -Dgallium-nine=true \
+        -Dvideo-codecs=h264dec,h264enc,h265dec,h265enc \
+        -Db_ndebug=true \
+        -Db_lto=false \
+        . output
+
+      meson configure --no-pager output
+      meson compile -C output
+
+      DESTDIR="${{targets.destdir}}" meson install --no-rebuild -C output
+
+  - uses: strip
+
+data:
+  - name: libs
+    items:
+      gles: libGLES*
+      egl: libEGL
+      gl: libGL
+      glapi: libglapi
+      xatracker: libxatracker*
+      osmesa: libOSMesa
+      gbm: libgbm
+      libd3dadapter9: d3d/d3dadapter9
+
+subpackages:
+  - range: libs
+    name: mesa-${{range.key}}
+    description: mesa ${{range.key}}
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/usr/lib
+          mv ${{targets.destdir}}/usr/lib/${{range.value}}.so* ${{targets.subpkgdir}}/usr/lib
+
+  - name: mesa-dev
+    pipeline:
+      - uses: split/dev
+    description: mesa dev
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 1970

--- a/scripts/install-wolfi-mesa-gl.sh
+++ b/scripts/install-wolfi-mesa-gl.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# NOTE(robinson) - this script installed mesa-gl 24.1. This is required because
+# the mesa-gl 24.2 on the wolfi package manager does not included libgallium, which
+# is required for the build to work. We can drop this work around as soon as mesa-gl
+# is fixed upstream.
+
+if [ "$ARCH" = "arm64" ] || [ "$ARCH" = "aarch64" ]; then
+  files=(
+    "mesa-gl-24.1.0-r0.718c913d.apk"
+    "mesa-glapi-24.1.0-r0.4390a503.apk"
+  )
+else
+  files=(
+    "mesa-gl-24.1-aarch64.0-r0.apk"
+    "mesa-glapi-24.1.0-r0-aarch64.apk"
+  )
+fi
+
+for file in "${files[@]}"; do
+  echo "Downloading ${file}"
+  wget "https://utic-public-cf.s3.amazonaws.com/$file"
+  apk add --allow-untrusted "${file}"
+  rm "${file}"
+done

--- a/scripts/install-wolfi-mesa-gl.sh
+++ b/scripts/install-wolfi-mesa-gl.sh
@@ -7,13 +7,13 @@
 
 if [ "$ARCH" = "arm64" ] || [ "$ARCH" = "aarch64" ]; then
   files=(
-    "mesa-gl-24.1.0-r0.718c913d.apk"
-    "mesa-glapi-24.1.0-r0.4390a503.apk"
+    "mesa-gl-24.1-aarch64.0-r0.apk"
+    "mesa-glapi-24.1.0-r0-aarch64.apk"
   )
 else
   files=(
-    "mesa-gl-24.1-aarch64.0-r0.apk"
-    "mesa-glapi-24.1.0-r0-aarch64.apk"
+    "mesa-gl-24.1.0-r0.718c913d.apk"
+    "mesa-glapi-24.1.0-r0.4390a503.apk"
   )
 fi
 


### PR DESCRIPTION
###  Summary

In #44 , we implemented a workaround install `mesa-gl` 24.1 because `libgallium` was not included in `mesa-gl` 24.2 in the `wolfi` package manager, causing our builds to break. #44 only included an `amd64` `mesa-gl` package. This PR adds an `arm64` package, which will allow to fix downstream `arm64` builds that are currently broken.
