### PR TITLE
fix: detect arch in wolfi install scripts

### DIFF
--- a/scripts/docker-dl-wolfi-packages.sh
+++ b/scripts/docker-dl-wolfi-packages.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+ARCH=$(uname -m)
+
 if [ "$ARCH" = "arm64" ] || [ "$ARCH" = "aarch64" ]; then
   files=(
     "poppler-23.09.0-r0-aarch64.apk"

--- a/scripts/docker-dl-wolfi-packages.sh
+++ b/scripts/docker-dl-wolfi-packages.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-ARCH=$(uname -m)
-
 if [ "$ARCH" = "arm64" ] || [ "$ARCH" = "aarch64" ]; then
   files=(
     "poppler-23.09.0-r0-aarch64.apk"

--- a/scripts/install-wolfi-mesa-gl.sh
+++ b/scripts/install-wolfi-mesa-gl.sh
@@ -5,6 +5,8 @@
 # is required for the build to work. We can drop this work around as soon as mesa-gl
 # is fixed upstream.
 
+ARCH=$(uname -m)
+
 if [ "$ARCH" = "arm64" ] || [ "$ARCH" = "aarch64" ]; then
   files=(
     "mesa-gl-24.1-aarch64.0-r0.apk"


### PR DESCRIPTION
###  Summary

Updates `wolfi` install scripts to detect the chip architecture and install the appropriate packages. Installing packages for the wrong architecture caused build errors in the `unstructured` repo.

### Test instructions

[This job](https://github.com/Unstructured-IO/unstructured/actions/runs/10947571067/job/30396597670?pr=3647) successfully ran with the fix in the `unstructured` repo.

