### PR TITLE
fix: reenable `rocky-linux` build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         architecture: ["arm64", "amd64"]
-        image: ["wolfi-base", "wolfi-py3.12-slim", "rocky9.2-slim"] # #"rocky9.2-gpu", "rocky9.2-slim", "rocky9.2-cpu"]
+        image: ["wolfi-base", "wolfi-py3.12-slim", "rocky9.2-slim", "rocky9.2-cpu"] # "rocky9.2-gpu"
     runs-on: ubuntu-latest-m
     needs: [set-short-sha]
     env:
@@ -65,7 +65,7 @@ jobs:
   publish-images:
     strategy:
       matrix:
-        image: ["wolfi-base", "wolfi-py3.12-slim", "rocky9.2-slim"] # #"rocky9.2-gpu", "rocky9.2-slim", "rocky9.2-cpu"]
+        image: ["wolfi-base", "wolfi-py3.12-slim", "rocky9.2-slim", "rocky9.2-cpu"] # "rocky9.2-gpu"
         # image: ["wolfi-base", "wolfi-py3.12-slim", "rocky9.2-gpu","rocky9.2-slim", "rocky9.2-cpu" ]
     env:
       SHORT_SHA: ${{ needs.set-short-sha.outputs.short_sha }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         architecture: ["arm64", "amd64"]
-        image: ["wolfi-base", "wolfi-py3.12-slim", "rocky9.2-gpu", "rocky9.2-slim", "rocky9.2-cpu"]
+        image: ["wolfi-base", "wolfi-py3.12-slim", "rocky9.2-slim"] # #"rocky9.2-gpu", "rocky9.2-slim", "rocky9.2-cpu"]
     runs-on: ubuntu-latest-m
     needs: [set-short-sha]
     env:
@@ -65,7 +65,8 @@ jobs:
   publish-images:
     strategy:
       matrix:
-        image: ["wolfi-base", "wolfi-py3.12-slim", "rocky9.2-gpu","rocky9.2-slim", "rocky9.2-cpu" ]
+        image: ["wolfi-base", "wolfi-py3.12-slim", "rocky9.2-slim"] # #"rocky9.2-gpu", "rocky9.2-slim", "rocky9.2-cpu"]
+        # image: ["wolfi-base", "wolfi-py3.12-slim", "rocky9.2-gpu","rocky9.2-slim", "rocky9.2-cpu" ]
     env:
       SHORT_SHA: ${{ needs.set-short-sha.outputs.short_sha }}
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         architecture: ["arm64", "amd64"]
-        image: ["wolfi-base", "wolfi-py3.12-slim", "rocky9.2-slim", "rocky9.2-cpu"] # "rocky9.2-gpu"
+        image: ["wolfi-base", "wolfi-py3.12-slim", "rocky9.2-slim", "rocky9.2-cpu", "rocky9.2-gpu"]
     runs-on: ubuntu-latest-m
     needs: [set-short-sha]
     env:
@@ -65,8 +65,7 @@ jobs:
   publish-images:
     strategy:
       matrix:
-        image: ["wolfi-base", "wolfi-py3.12-slim", "rocky9.2-slim", "rocky9.2-cpu"] # "rocky9.2-gpu"
-        # image: ["wolfi-base", "wolfi-py3.12-slim", "rocky9.2-gpu","rocky9.2-slim", "rocky9.2-cpu" ]
+        image: ["wolfi-base", "wolfi-py3.12-slim", "rocky9.2-slim", "rocky9.2-cpu", "rocky9.2-gpu"]
     env:
       SHORT_SHA: ${{ needs.set-short-sha.outputs.short_sha }}
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,8 +25,7 @@ jobs:
     strategy:
       matrix:
         architecture: ["arm64", "amd64"]
-        # NOTE(robinson) - temporarily disabled rocky due to build failures
-        image: ["wolfi-base", "wolfi-py3.12-slim"] # ["rocky9.2-gpu", "rocky9.2-slim", "rocky9.2-cpu"]
+        image: ["wolfi-base", "wolfi-py3.12-slim", "rocky9.2-gpu", "rocky9.2-slim", "rocky9.2-cpu"]
     runs-on: ubuntu-latest-m
     needs: [set-short-sha]
     env:
@@ -66,8 +65,7 @@ jobs:
   publish-images:
     strategy:
       matrix:
-        # NOTE(robinson) - temporarily disabled rocky due to build failures
-        image: ["wolfi-base", "wolfi-py3.12-slim"] # "rocky9.2-gpu","rocky9.2-slim", "rocky9.2-cpu" ]
+        image: ["wolfi-base", "wolfi-py3.12-slim", "rocky9.2-gpu","rocky9.2-slim", "rocky9.2-cpu" ]
     env:
       SHORT_SHA: ${{ needs.set-short-sha.outputs.short_sha }}
     runs-on: ubuntu-latest

--- a/dockerfiles/deps/base.sh
+++ b/dockerfiles/deps/base.sh
@@ -25,7 +25,7 @@ if [[ "$GPU_ENABLED" == "true" ]]; then
   echo "Installing CUDA dependencies"
   if [[ "$ARCH" == "x86_64" ]] || [[ "$ARCH" == "amd64" ]]; then
     dnf config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/cuda-rhel9.repo
-    dnf -y install nvidia-driver nvidia-settings cuda-drivers cuda-toolkit
+    dnf -y install nvidia-driver nvidia-settings cuda-toolkit
   else
     dnf config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel9/cross-linux-sbsa/cuda-rhel9-cross-linux-sbsa.repo
     dnf -y install cuda-cross-sbsa-11-8

--- a/dockerfiles/deps/base.sh
+++ b/dockerfiles/deps/base.sh
@@ -25,7 +25,7 @@ if [[ "$GPU_ENABLED" == "true" ]]; then
   echo "Installing CUDA dependencies"
   if [[ "$ARCH" == "x86_64" ]] || [[ "$ARCH" == "amd64" ]]; then
     dnf config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/cuda-rhel9.repo
-    dnf -y install nvidia-driver nvidia-settings cuda-driver cuda-toolkit
+    dnf -y install nvidia-driver nvidia-settings cuda-toolkit # cuda-driver
   else
     dnf config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel9/cross-linux-sbsa/cuda-rhel9-cross-linux-sbsa.repo
     dnf -y install cuda-cross-sbsa-11-8

--- a/dockerfiles/deps/base.sh
+++ b/dockerfiles/deps/base.sh
@@ -25,7 +25,7 @@ if [[ "$GPU_ENABLED" == "true" ]]; then
   echo "Installing CUDA dependencies"
   if [[ "$ARCH" == "x86_64" ]] || [[ "$ARCH" == "amd64" ]]; then
     dnf config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/cuda-rhel9.repo
-    dnf -y install nvidia-driver nvidia-settings cuda-toolkit # cuda-driver
+    dnf -y install nvidia-driver nvidia-settings cuda-drivers cuda-toolkit
   else
     dnf config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel9/cross-linux-sbsa/cuda-rhel9-cross-linux-sbsa.repo
     dnf -y install cuda-cross-sbsa-11-8

--- a/dockerfiles/deps/python.sh
+++ b/dockerfiles/deps/python.sh
@@ -15,9 +15,6 @@ cd ..
 rm -rf Python-3.10.14*
 pip3.10 install --upgrade setuptools pip
 ln -s /usr/local/bin/python3.10 /usr/local/bin/python3
-# (Trevor) Setuptools for 3.9 has vulns, so we need to remove it
-rpm --nodeps -e python3-setuptools-53.0.0-12.el9.noarch
-rm -rf /usr/local/lib/python3.9/site-packages/setuptools
 dnf -y groupremove "Development Tools"
 rm -rf /var/cache/yum/*
 dnf clean all


### PR DESCRIPTION
###  Summary

Fixes and reenables `rocky-linux` builds that have been broken for the past couple weeks. Implements the following updates:

- `python3-setuptools-53.0.0-12.el9.noarch` is no longer removed, because it doesn't get installed. It was previoulsy removed due to a CVE.
- Remove `dnf install cuda-driver`, because the CUDA drivers are provided by [`cuda-toolkit`](https://docs.nvidia.com/cuda/cuda-installation-guide-microsoft-windows/index.html#download-the-nvidia-cuda-toolkit) and [`nvidia-driver`](https://docs.nvidia.com/cuda/cuda-installation-guide-linux/#driver-installation). The build was previously failing with `Error: Unable to find a match: cuda-driver`.

### Test instructions

All images should now build on the feature branch.
