### PR TITLE
chore: upgrade python version to 3.12 for base images (except wolfi)

### DIFF
--- a/dockerfiles/deps/python.sh
+++ b/dockerfiles/deps/python.sh
@@ -14,7 +14,7 @@ make altinstall
 cd ..
 rm -rf Python-3.12.3*
 pip3.12 install --upgrade setuptools pip
-ln -s /usr/local/bin/python3.10 /usr/local/bin/python3
+ln -s /usr/local/bin/python3.12 /usr/local/bin/python3
 dnf -y groupremove "Development Tools"
 rm -rf /var/cache/yum/*
 dnf clean all

--- a/dockerfiles/deps/python.sh
+++ b/dockerfiles/deps/python.sh
@@ -6,14 +6,14 @@ dnf -y install bzip2-devel libffi-devel make git sqlite-devel openssl-devel
 dnf -y install python-pip
 pip3.9 install --upgrade setuptools pip
 dnf -y groupinstall "Development Tools"
-curl -O https://www.python.org/ftp/python/3.10.14/Python-3.10.14.tgz
-tar -xzf Python-3.10.14.tgz
-cd Python-3.10.14/ || exit 1
+curl -O https://www.python.org/ftp/python/3.12.3/Python-3.12.3.tgz
+tar -xzf Python-3.12.3.tgz
+cd Python-3.12.3/ || exit 1
 ./configure --enable-optimizations
 make altinstall
 cd ..
-rm -rf Python-3.10.14*
-pip3.10 install --upgrade setuptools pip
+rm -rf Python-3.12.3*
+pip3.12 install --upgrade setuptools pip
 ln -s /usr/local/bin/python3.10 /usr/local/bin/python3
 dnf -y groupremove "Development Tools"
 rm -rf /var/cache/yum/*


### PR DESCRIPTION
###  Summary

Upgrade python3.10 -> pytho3.12 for `deps/python.sh` script which applies to all base images except the wolfi images.

### Test instructions
```
DOCKERFILE=rocky9.2-cpu  make build-base-images
docker run -it quay.io/unstructured-io/build-base-images:rocky9.2-cpu-amd64-c1fbebd /bin/bash
[root@f43a6a4b2a99 /]# python3 --version
Python 3.12.3
```

