### PR TITLE
bump to official release of libreoffice 25.2

### DIFF
--- a/scripts/docker-dl-wolfi-packages.sh
+++ b/scripts/docker-dl-wolfi-packages.sh
@@ -4,14 +4,12 @@ if [ "$ARCH" = "arm64" ] || [ "$ARCH" = "aarch64" ]; then
   files=(
     "poppler-23.09.0-r0-aarch64.apk"
     "pandoc-3.1.8-r0-aarch64.apk"
-    "libreoffice-24-24.2.5.2-r1-aarch64.apk"
     "nltk_data.tgz"
   )
 else
   files=(
     "poppler-23.09.0-r0.apk"
     "pandoc-3.1.8-r0.apk"
-    "libreoffice-24-24.2.5.2-r1.apk"
     "nltk_data.tgz"
   )
 fi

--- a/scripts/install-wolfi-libreoffice.sh
+++ b/scripts/install-wolfi-libreoffice.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-apk add --allow-untrusted packages/libreoffice-24-24.2.5.2-r1.apk
+apk add libreoffice-25.2
 
 ln -s /usr/lib/libreoffice/program/soffice.bin /usr/bin/libreoffice
 ln -s /usr/lib/libreoffice/program/soffice.bin /usr/bin/soffice


### PR DESCRIPTION
###  Summary

Bump libreoffice to 25.2, which has a official package now on wolfi base repo. This PR also removes download of the outdated libreoffice 24 from script.
It also updates python 3.13 to 3.13.4-rc0 for a critical cve fix.


