### PR TITLE
update image daily

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
     branches: [main]
   workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * *'
 
 env:
   DOCKER_REPOSITORY: quay.io/unstructured-io


### PR DESCRIPTION
###  Summary

This PR adds a cron trigger to ci so it builds new images daily to get latest fixes for potential cve. This avoids blockers in downstream development.

