### PR TITLE
fix: Install poppler-utils and poppler-glib

### DIFF
--- a/dockerfiles/wolfi-base/Dockerfile
+++ b/dockerfiles/wolfi-base/Dockerfile
@@ -9,7 +9,7 @@ USER root
 RUN apk update && \
     apk add libxml2 python-3.12 python-3.12-base py3.12-pip glib \
       mesa-gl mesa-libgallium cmake bash libmagic wget git openjpeg \
-      poppler libreoffice && \
+      poppler poppler-utils poppler-glib libreoffice && \
     apk add --allow-untrusted packages/pandoc-3.1.8-r0.apk && \
     ./install-wolfi-tesseract.sh && rm install-wolfi-tesseract.sh && \
     apk cache clean && \

--- a/scripts/docker-dl-wolfi-packages.sh
+++ b/scripts/docker-dl-wolfi-packages.sh
@@ -2,13 +2,11 @@
 
 if [ "$ARCH" = "arm64" ] || [ "$ARCH" = "aarch64" ]; then
   files=(
-    "poppler-23.09.0-r0-aarch64.apk"
     "pandoc-3.1.8-r0-aarch64.apk"
     "nltk_data.tgz"
   )
 else
   files=(
-    "poppler-23.09.0-r0.apk"
     "pandoc-3.1.8-r0.apk"
     "nltk_data.tgz"
   )


### PR DESCRIPTION
###  Summary

Several weeks ago, the wolfi poppler package was [split into separate packages](https://github.com/wolfi-dev/os/commit/fc98802c2565d5eb4788f5e7d4e91e92b5011bba). We created a [fix](https://github.com/Unstructured-IO/core-product/pull/1167) for this in core-product, but the problem has also popped up in [unstructured CI failures](https://github.com/Unstructured-IO/unstructured/actions/runs/17506946725/job/49732188077).

This fix adds the necessary additional poppler packages to the base image.

Also, I noticed that we were still manually downloading the package for poppler even though it's now available in the chainguard index. I removed the line that downloads the poppler package.

### Test instructions

In a built docker image, the command line command `pdfinfo -v` should respond with the current version of `pdfinfo` instead of an error.