### PR TITLE
fix: update jaraco.context to resolve CVE

### DIFF
--- a/dockerfiles/wolfi-base/Dockerfile
+++ b/dockerfiles/wolfi-base/Dockerfile
@@ -18,6 +18,9 @@ RUN apk update && \
     ln -s /usr/lib/libreoffice/program/soffice.bin /usr/bin/soffice && \
     chmod +x /usr/lib/libreoffice/program/soffice.bin
 
+# NOTE(alan): To resolve GHSA-58pv-8j8x-9vj2
+RUN pip install --no-cache-dir --upgrade "jaraco.context>=6.1"
+
 ARG NB_UID=1000
 ARG NB_USER=notebook-user
 RUN addgroup --gid ${NB_UID} ${NB_USER} && \
@@ -29,9 +32,6 @@ COPY --chown=${NB_USER} scripts/initialize-libreoffice.sh ${HOME}/initialize-lib
 ENV TESSDATA_PREFIX=/usr/local/share/tessdata
 USER ${NB_USER}
 WORKDIR ${HOME}
-
-# NOTE(alan): To resolve GHSA-58pv-8j8x-9vj2
-RUN pip install --no-cache-dir --upgrade "jaraco.context>=6.1"
 
 # NOTE(mike): This dummy call is a workaround for libreoffice not executing commands properly at the start of the container.
 # The issue is decribed here: https://github.com/Unstructured-IO/unstructured/issues/3105

--- a/dockerfiles/wolfi-base/Dockerfile
+++ b/dockerfiles/wolfi-base/Dockerfile
@@ -31,7 +31,7 @@ USER ${NB_USER}
 WORKDIR ${HOME}
 
 # NOTE(alan): To resolve GHSA-58pv-8j8x-9vj2
-RUN pip install --no-cache-dir --user --upgrade "jaraco.context>=6.1"
+RUN pip install --no-cache-dir --upgrade "jaraco.context>=6.1"
 
 # NOTE(mike): This dummy call is a workaround for libreoffice not executing commands properly at the start of the container.
 # The issue is decribed here: https://github.com/Unstructured-IO/unstructured/issues/3105

--- a/dockerfiles/wolfi-base/Dockerfile
+++ b/dockerfiles/wolfi-base/Dockerfile
@@ -31,7 +31,7 @@ USER ${NB_USER}
 WORKDIR ${HOME}
 
 # NOTE(alan): To resolve GHSA-58pv-8j8x-9vj2
-RUN $PIP install --no-cache-dir --user --upgrade "jaraco.context>=6.1"
+RUN pip install --no-cache-dir --user --upgrade "jaraco.context>=6.1"
 
 # NOTE(mike): This dummy call is a workaround for libreoffice not executing commands properly at the start of the container.
 # The issue is decribed here: https://github.com/Unstructured-IO/unstructured/issues/3105

--- a/dockerfiles/wolfi-base/Dockerfile
+++ b/dockerfiles/wolfi-base/Dockerfile
@@ -18,9 +18,6 @@ RUN apk update && \
     ln -s /usr/lib/libreoffice/program/soffice.bin /usr/bin/soffice && \
     chmod +x /usr/lib/libreoffice/program/soffice.bin
 
-# NOTE(alan): To resolve GHSA-58pv-8j8x-9vj2
-RUN pip install --no-cache-dir --upgrade "jaraco.context>=6.1"
-
 ARG NB_UID=1000
 ARG NB_USER=notebook-user
 RUN addgroup --gid ${NB_UID} ${NB_USER} && \
@@ -39,5 +36,11 @@ WORKDIR ${HOME}
 # It is crucial to run as a non-root user, otherwise the config file will be created in /root
 # Moreover, we expect the command to exit with code 81
 RUN ./initialize-libreoffice.sh && rm initialize-libreoffice.sh
+
+USER root
+
+RUN pip uninstall -y setuptools && pip cache purge
+
+USER ${NB_USER}
 
 CMD ["/bin/bash"]

--- a/dockerfiles/wolfi-base/Dockerfile
+++ b/dockerfiles/wolfi-base/Dockerfile
@@ -30,6 +30,9 @@ ENV TESSDATA_PREFIX=/usr/local/share/tessdata
 USER ${NB_USER}
 WORKDIR ${HOME}
 
+# NOTE(alan): To resolve GHSA-58pv-8j8x-9vj2
+RUN $PIP install --no-cache-dir --user --upgrade "jaraco.context>=6.1"
+
 # NOTE(mike): This dummy call is a workaround for libreoffice not executing commands properly at the start of the container.
 # The issue is decribed here: https://github.com/Unstructured-IO/unstructured/issues/3105
 # soffice running twice explanation: https://github.com/jodconverter/jodconverter/issues/48#issuecomment-1863864333

--- a/dockerfiles/wolfi-py3.12-slim/Dockerfile
+++ b/dockerfiles/wolfi-py3.12-slim/Dockerfile
@@ -7,8 +7,6 @@ RUN apk update && \
     apk cache clean
 
 # NOTE(alan): To resolve GHSA-58pv-8j8x-9vj2
-RUN pip uninstall -y jaraco.context && \
-    pip install --no-cache-dir --force-reinstall jaraco.context>=6.1.0 && \
-    pip verify jaraco.context
+RUN python3.12 -m pip install --no-cache-dir --force-reinstall jaraco.context>=6.1.0
 
 CMD ["/bin/bash"]

--- a/dockerfiles/wolfi-py3.12-slim/Dockerfile
+++ b/dockerfiles/wolfi-py3.12-slim/Dockerfile
@@ -7,6 +7,6 @@ RUN apk update && \
     apk cache clean
 
 # NOTE(alan): To resolve GHSA-58pv-8j8x-9vj2
-RUN pip install --no-cache-dir --user --upgrade "jaraco.context>=6.1"
+RUN pip install --no-cache-dir --upgrade "jaraco.context>=6.1"
 
 CMD ["/bin/bash"]

--- a/dockerfiles/wolfi-py3.12-slim/Dockerfile
+++ b/dockerfiles/wolfi-py3.12-slim/Dockerfile
@@ -7,6 +7,6 @@ RUN apk update && \
     apk cache clean
 
 # NOTE(alan): To resolve GHSA-58pv-8j8x-9vj2
-RUN python3.12 -m pip install --no-cache-dir --force-reinstall jaraco.context>=6.1.0
+RUN pip uninstall -y setuptools && pip cache purge
 
 CMD ["/bin/bash"]

--- a/dockerfiles/wolfi-py3.12-slim/Dockerfile
+++ b/dockerfiles/wolfi-py3.12-slim/Dockerfile
@@ -6,4 +6,7 @@ RUN apk update && \
     apk add bash python-3.12 py3.12-pip && \
     apk cache clean
 
+# NOTE(alan): To resolve GHSA-58pv-8j8x-9vj2
+RUN $PIP install --no-cache-dir --user --upgrade "jaraco.context>=6.1"
+
 CMD ["/bin/bash"]

--- a/dockerfiles/wolfi-py3.12-slim/Dockerfile
+++ b/dockerfiles/wolfi-py3.12-slim/Dockerfile
@@ -7,6 +7,6 @@ RUN apk update && \
     apk cache clean
 
 # NOTE(alan): To resolve GHSA-58pv-8j8x-9vj2
-RUN $PIP install --no-cache-dir --user --upgrade "jaraco.context>=6.1"
+RUN pip install --no-cache-dir --user --upgrade "jaraco.context>=6.1"
 
 CMD ["/bin/bash"]

--- a/dockerfiles/wolfi-py3.12-slim/Dockerfile
+++ b/dockerfiles/wolfi-py3.12-slim/Dockerfile
@@ -7,6 +7,8 @@ RUN apk update && \
     apk cache clean
 
 # NOTE(alan): To resolve GHSA-58pv-8j8x-9vj2
-RUN pip install --no-cache-dir --upgrade "jaraco.context>=6.1"
+RUN pip uninstall -y jaraco.context && \
+    pip install --no-cache-dir --force-reinstall jaraco.context>=6.1.0 && \
+    pip verify jaraco.context
 
 CMD ["/bin/bash"]


### PR DESCRIPTION
###  Summary

GHSA-58pv-8j8x-9vj2 involves the Python package `jaraco.context`, which is past of the base Python toolchain (as opposed to unstructured-specific deps). This PR pulls in the fix

### Test instructions

Grype scan should *not* show GHSA-58pv-8j8x-9vj2.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Addresses security advisory GHSA-58pv-8j8x-9vj2 by removing vulnerable Python tooling from Docker images.
> 
> - Uninstalls `setuptools` and purges pip cache in `dockerfiles/wolfi-base/Dockerfile` and `dockerfiles/wolfi-py3.12-slim/Dockerfile`
> - In `wolfi-base`, temporarily elevates to `root` for the uninstall, then restores the non-root user
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e54aeddee830b6bb21b05ea1136c3b4d1a07ed64. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->