### PR TITLE
chore(deps): bump claude-code-action to v1

### DIFF
--- a/.github/workflows/claude.yaml
+++ b/.github/workflows/claude.yaml
@@ -35,4 +35,4 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.GH_ANTHROPIC_API_KEY }}
           claude_args: |
-            --allowedTools "Bash(git:*),View,GlobTool,GrepTool,BatchTool"
+            --allowedTools "Bash(git:*),Read,Glob,Grep"

--- a/.github/workflows/claude.yaml
+++ b/.github/workflows/claude.yaml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.GH_ANTHROPIC_API_KEY }}
           allowed_tools: "Bash(git:*),View,GlobTool,GrepTool,BatchTool"

--- a/.github/workflows/claude.yaml
+++ b/.github/workflows/claude.yaml
@@ -34,4 +34,5 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.GH_ANTHROPIC_API_KEY }}
-          allowed_tools: "Bash(git:*),View,GlobTool,GrepTool,BatchTool"
+          claude_args: |
+            --allowedTools "Bash(git:*),View,GlobTool,GrepTool,BatchTool"


### PR DESCRIPTION
Bumps `anthropics/claude-code-action` from `@beta` to `@v1`.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Unstructured-IO/base-images/pull/75?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

